### PR TITLE
Establish public project baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zevarix

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report a reproducible problem with Pantheon Local Tools
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a problem. Do not include credentials, tokens, SSH keys, or other secrets.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest reliable set of steps and commands that reproduces the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, shell, Lando version, Terminus version, and relevant tool version when known.
+      placeholder: |
+        OS:
+        Shell:
+        Lando:
+        Terminus:
+        Pantheon Local Tools:
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Relevant output
+      description: Paste sanitized output or logs. Remove credentials and private data first.
+      render: shell
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I removed credentials, tokens, keys, passwords, and other secrets from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose an improvement to Pantheon Local Tools
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the behavior you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Describe workarounds or alternative designs you considered.
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety or compatibility considerations
+      description: Note any remote writes, destructive operations, path handling, platform compatibility, or configuration concerns.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Validation
+
+- [ ] I tested the changed behavior.
+- [ ] I added or updated tests where appropriate.
+- [ ] I updated user-facing documentation where appropriate.
+- [ ] I did not add credentials, tokens, machine-specific paths, or other secrets.
+- [ ] Destructive or remote-write behavior remains explicit and fail-safe.
+
+## Notes for reviewers
+
+Call out any tradeoffs, compatibility concerns, or follow-up work that would help review this change.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,56 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes shellcheck
+
+      - name: Validate shell syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find . -type f \
+            \( -name '*.sh' -o -path './bin/*' \) \
+            -not -path './.git/*' \
+            -print)
+
+          if ((${#files[@]} == 0)); then
+            echo 'No shell files to validate yet.'
+            exit 0
+          fi
+
+          for file in "${files[@]}"; do
+            bash -n "$file"
+          done
+
+      - name: Run ShellCheck
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find . -type f \
+            \( -name '*.sh' -o -path './bin/*' \) \
+            -not -path './.git/*' \
+            -print)
+
+          if ((${#files[@]} == 0)); then
+            echo 'No shell files to lint yet.'
+            exit 0
+          fi
+
+          shellcheck "${files[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# macOS
+.DS_Store
+
+# Editor and IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Local environment and secrets
+.env
+.env.*
+!.env.example
+*.local
+
+# Test and coverage output
+coverage/
+tmp/
+
+# Local tool configuration must not be committed
+config.local

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Code of Conduct
+
+Pantheon Local Tools is intended to be a welcoming, practical, and professional open-source project.
+
+## Expected behavior
+
+Contributors and maintainers should:
+
+- communicate respectfully and constructively;
+- critique ideas and code rather than people;
+- assume good intent while still addressing problems directly;
+- welcome questions from people with different experience levels;
+- keep technical disagreement focused on evidence, tradeoffs, and project goals; and
+- respect privacy and do not publish another person's private information without permission.
+
+## Unacceptable behavior
+
+Harassment, threats, discriminatory remarks, personal attacks, deliberate disruption, sexualized conduct, doxxing, and other behavior that makes participation unsafe or hostile are not acceptable.
+
+## Enforcement
+
+Project maintainers may edit, remove, or reject comments, commits, issues, pull requests, or other contributions that violate this policy. Repeated or serious violations may result in temporary or permanent exclusion from project spaces.
+
+If you experience or witness a conduct problem, contact the repository owner privately through an appropriate trusted channel. Reports will be handled as discreetly as practical.
+
+This policy applies in repository discussions and in other project spaces when someone is representing the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+Thanks for helping improve Pantheon Local Tools.
+
+## Before you start
+
+- Search existing issues and pull requests before opening a duplicate.
+- For behavior changes, prefer opening an issue first so the intended workflow can be agreed on before implementation.
+- Keep changes focused. Small pull requests are easier to review and safer to merge.
+
+## Development setup
+
+The project targets macOS/Linux shell environments and expects Git, Bash, Terminus, and Lando.
+
+Until the first stable release, supported versions and installation details may change as integration testing continues.
+
+## Pull requests
+
+1. Fork the repository or create a feature branch if you have write access.
+2. Make the smallest coherent change that solves the problem.
+3. Add or update tests for changed behavior.
+4. Run the repository validation commands documented in the README.
+5. Update documentation when user-visible behavior changes.
+6. Open a pull request against `main` and explain what changed, why, and how it was tested.
+
+The repository uses squash merging so each reviewed pull request becomes one canonical integration commit.
+
+## Safety expectations
+
+This project interacts with developer environments and Pantheon sites. Changes must fail safely.
+
+- Do not overwrite an existing checkout without explicit user action.
+- Do not embed credentials, tokens, machine-specific paths, or organization-specific secrets.
+- Treat remote writes, destructive local operations, and environment rebuilds as explicit actions rather than hidden side effects.
+- Prefer Terminus and Lando's documented interfaces over scraping or guessing implementation details.
+
+## Reporting security issues
+
+Do not open a public issue for a suspected vulnerability involving credentials, command injection, unsafe file writes, or another security-sensitive behavior. Follow `SECURITY.md` instead.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zevarix
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local development helpers for Pantheon and Lando workflows.
 
-This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout or organization naming conventions.
+This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon tags, or project-family folders.
 
 ## Planned commands
 
@@ -14,10 +14,13 @@ This project is being built to make common Pantheon local-development tasks safe
 
 - Use Terminus as the authoritative source for Pantheon site/environment data.
 - Keep local filesystem roots configurable per developer.
-- Support Pantheon site tags for routing sites into local project families.
+- Allow optional Pantheon site-tag-to-folder routing through user configuration.
+- Keep all organization-specific prefixes, tags, and local folder mappings in user configuration rather than source code.
 - Generate per-checkout `.lando.local.yml` files for isolated multidev names and URLs.
 - Fail safely rather than overwrite an existing checkout or guess when routing is ambiguous.
 - Keep machine-specific configuration outside the repository.
+
+For example, one organization might map a Pantheon tag such as `Agency` to a local `agency/` project family while another developer may use no tag routing at all. Those choices belong in that developer's local configuration and are not project defaults.
 
 ## Status
 
@@ -36,7 +39,7 @@ Exact supported versions will be documented after integration testing.
 
 ## Contributing
 
-Contributions are welcome. See `CONTRIBUTING.md` once the initial project baseline lands.
+Contributions are welcome. See `CONTRIBUTING.md`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local development helpers for Pantheon and Lando workflows.
 
-This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon tags, or project-family folders.
+This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon tags, or local directory mappings.
 
 ## Planned commands
 
@@ -14,13 +14,13 @@ This project is being built to make common Pantheon local-development tasks safe
 
 - Use Terminus as the authoritative source for Pantheon site/environment data.
 - Keep local filesystem roots configurable per developer.
-- Allow optional Pantheon site-tag-to-folder routing through user configuration.
-- Keep all organization-specific prefixes, tags, and local folder mappings in user configuration rather than source code.
+- Allow optional Pantheon tag-to-local-directory routing through user configuration.
+- Keep all organization-specific prefixes, Pantheon tags, and local directory mappings in user configuration rather than source code.
 - Generate per-checkout `.lando.local.yml` files for isolated multidev names and URLs.
 - Fail safely rather than overwrite an existing checkout or guess when routing is ambiguous.
 - Keep machine-specific configuration outside the repository.
 
-For example, one organization might map a Pantheon tag such as `Agency` to a local `agency/` project family while another developer may use no tag routing at all. Those choices belong in that developer's local configuration and are not project defaults.
+For example, one organization might map a Pantheon tag such as `Agency` to a local `agency/` directory while another developer may use no tag routing at all. Those choices belong in that developer's local configuration and are not project defaults.
 
 ## Status
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not disclose suspected security vulnerabilities in a public issue or pull request.
+
+Use GitHub's private vulnerability reporting feature for this repository when available. If private reporting is not available, contact the repository owner privately through an existing trusted channel before publishing details.
+
+Helpful reports include:
+
+- the affected command or file;
+- the conditions required to reproduce the issue;
+- the potential impact;
+- a minimal proof of concept when safe to provide; and
+- any suggested mitigation.
+
+Please avoid including real access tokens, passwords, SSH keys, database credentials, or other secrets in a report.
+
+## Scope
+
+Security-sensitive areas include command injection, unsafe path handling, accidental overwrites, credential exposure, unintended remote writes, privilege escalation, and execution of untrusted contributor code.
+
+Supported-version information will be added after the first release.

--- a/config.example
+++ b/config.example
@@ -1,0 +1,23 @@
+# Pantheon Local Tools user configuration example
+#
+# Copy this file to:
+#   ~/.config/pantheon-local-tools/config
+#
+# Machine- and organization-specific values belong in the user config, not
+# in this repository.
+
+# Root directory under which local Pantheon projects are organized.
+PANTHEON_LOCAL_ROOT="$HOME/lando"
+
+# Optional organization/site prefix. Leave empty when no shared prefix is used.
+PANTHEON_SITE_PREFIX=""
+
+# Optional Pantheon tag -> local folder routing.
+#
+# These examples are intentionally generic. Replace or remove them in your
+# local config. The implementation will fail rather than guess when routing is
+# ambiguous.
+declare -A PANTHEON_TAG_ROUTES=(
+  ["ExampleGroup"]="example-group"
+  ["AnotherGroup"]="another-group"
+)


### PR DESCRIPTION
## Summary

Establish the initial public-project baseline for Pantheon Local Tools.

- add MIT licensing and contributor/security/conduct guidance
- add CODEOWNERS, issue forms, and a pull request template
- add minimal read-only GitHub Actions validation for shell syntax and ShellCheck
- add a generic user configuration example
- document Pantheon **Tags** as the configurable source for optional tag-to-local-directory routing
- keep employer-, organization-, machine-, prefix-, tag-, and directory-specific values out of the repository

## Validation

- reviewed the branch diff against `main`
- confirmed no organization-specific tag names or local directory names were introduced
- GitHub Actions validation is expected to run on this PR

## Notes

This deliberately leaves `.agents/` out of the repository for now. The actual Pantheon/Lando command implementation will follow after we validate the relevant Terminus interfaces against a real local environment.