### PR TITLE
Generalize local provider architecture

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,11 +26,12 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Include OS, shell, Lando version, Terminus version, and relevant tool version when known.
+      description: Include OS, shell, local provider and version (for example DDEV or Lando), Terminus version, and tool version when known.
       placeholder: |
         OS:
         Shell:
-        Lando:
+        Local provider:
+        Provider version:
         Terminus:
         Pantheon Local Tools:
     validations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,9 @@ Thanks for helping improve Pantheon Local Tools.
 
 ## Development setup
 
-The project targets macOS/Linux shell environments and expects Git, Bash, Terminus, and Lando.
+The project targets macOS/Linux shell environments and expects Git, Bash, Terminus, and at least one supported local development provider.
+
+The first supported providers are DDEV and Lando. Changes to shared Pantheon/Terminus behavior should remain provider-neutral; provider-specific behavior belongs behind the provider boundary.
 
 Until the first stable release, supported versions and installation details may change as integration testing continues.
 
@@ -21,7 +23,8 @@ Until the first stable release, supported versions and installation details may 
 3. Add or update tests for changed behavior.
 4. Run the repository validation commands documented in the README.
 5. Update documentation when user-visible behavior changes.
-6. Open a pull request against `main` and explain what changed, why, and how it was tested.
+6. When changing provider behavior, validate the affected provider and avoid regressions in the other supported provider.
+7. Open a pull request against `main` and explain what changed, why, and how it was tested.
 
 The repository uses squash merging so each reviewed pull request becomes one canonical integration commit.
 
@@ -30,9 +33,11 @@ The repository uses squash merging so each reviewed pull request becomes one can
 This project interacts with developer environments and Pantheon sites. Changes must fail safely.
 
 - Do not overwrite an existing checkout without explicit user action.
-- Do not embed credentials, tokens, machine-specific paths, or organization-specific secrets.
-- Treat remote writes, destructive local operations, and environment rebuilds as explicit actions rather than hidden side effects.
-- Prefer Terminus and Lando's documented interfaces over scraping or guessing implementation details.
+- Do not embed credentials, tokens, machine-specific paths, organization-specific tags, or private naming conventions.
+- Treat remote writes, destructive local operations, and environment start/rebuild operations as explicit actions rather than hidden side effects.
+- Prefer Terminus, DDEV, and Lando's documented interfaces over scraping or guessing implementation details.
+- Do not make shared Pantheon logic depend directly on one local provider.
+- If provider detection is ambiguous, fail and require an explicit provider instead of guessing.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,48 @@
 # Pantheon Local Tools
 
-Local development helpers for Pantheon and Lando workflows.
+Local development helpers for Pantheon workflows across supported local development providers.
 
-This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon tags, or local directory mappings.
+This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon tags, local directory mappings, or local development stack.
 
 ## Planned commands
 
-- `pantheon-multidev SITE.ENV` — clone a Pantheon multidev into an isolated local Lando checkout.
+- `pantheon-multidev SITE.ENV` — clone a Pantheon multidev into an isolated local checkout and configure the selected local provider.
 - `pantheon-pull ENV` — refresh database/files for a normal local checkout without changing checked-out code.
-- `pantheon-status` — show the local checkout, Lando identity, local URL, Git branch, and recorded Pantheon data source.
+- `pantheon-status` — show the local checkout, selected provider, local URL, Git branch, and recorded Pantheon data source.
+
+## Local development providers
+
+The first supported providers are **DDEV** and **Lando**.
+
+Drupal.org currently recommends DDEV for Drupal local development, while Pantheon documents both local-development approaches. Pantheon Local Tools therefore keeps Pantheon and Terminus behavior in a shared core and delegates provider-specific behavior to adapters.
+
+Provider selection is designed to be explicit and fail-safe. The implementation will resolve the provider in this order:
+
+1. an explicit command option such as `--provider ddev` or `--provider lando`;
+2. the user's configured default provider;
+3. an unambiguous provider configuration already present in the cloned project;
+4. otherwise, fail and ask the user to choose rather than guessing.
+
+Provider-specific local configuration must remain local to the developer's checkout. DDEV supports local `config.*.yaml` overrides such as `.ddev/config.local.yaml`; Lando checkouts can use `.lando.local.yml` for local overrides.
 
 ## Design goals
 
 - Use Terminus as the authoritative source for Pantheon site/environment data.
+- Keep Pantheon operations independent from the developer's local container provider.
 - Keep local filesystem roots configurable per developer.
 - Allow optional Pantheon tag-to-local-directory routing through user configuration.
-- Keep all organization-specific prefixes, Pantheon tags, and local directory mappings in user configuration rather than source code.
-- Generate per-checkout `.lando.local.yml` files for isolated multidev names and URLs.
-- Fail safely rather than overwrite an existing checkout or guess when routing is ambiguous.
-- Keep machine-specific configuration outside the repository.
+- Keep all organization-specific prefixes, Pantheon tags, local directory mappings, and provider preferences in user configuration rather than source code.
+- Configure isolated local names and URLs without committing machine-specific overrides to the Pantheon site repository.
+- Never overwrite an existing checkout or silently choose between ambiguous providers.
+- Treat environment start/rebuild operations and remote writes as explicit actions.
 
-For example, one organization might map a Pantheon tag such as `Agency` to a local `agency/` directory while another developer may use no tag routing at all. Those choices belong in that developer's local configuration and are not project defaults.
+For example, one organization might map a Pantheon tag such as `Agency` to a local `agency/` directory while another developer may use no tag routing at all. One developer may use DDEV while another uses Lando. Those choices belong in each developer's local configuration and are not project defaults.
+
+See [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) for the provider boundary and upstream references.
 
 ## Status
 
-Early development. The first implementation is being validated against real Pantheon, Terminus, and Lando environments before the initial release.
+Early development. The first implementation is being validated against real Pantheon and Terminus environments with both DDEV and Lando provider behavior before the initial release.
 
 ## Requirements
 
@@ -33,7 +51,7 @@ The initial implementation targets macOS/Linux shells and expects:
 - Git
 - Bash
 - Terminus
-- Lando
+- at least one supported local provider: DDEV or Lando
 
 Exact supported versions will be documented after integration testing.
 

--- a/config.example
+++ b/config.example
@@ -7,12 +7,19 @@
 # in this repository.
 
 # Root directory under which local Pantheon projects are organized.
-PANTHEON_LOCAL_ROOT="$HOME/lando"
+# Override this with any layout that works for your machine.
+PANTHEON_LOCAL_ROOT="$HOME/sites/pantheon"
+
+# Local development provider.
+# Supported planned values: auto, ddev, lando
+# "auto" uses an unambiguous project configuration when one is present and
+# otherwise requires an explicit choice rather than guessing.
+PANTHEON_LOCAL_PROVIDER="auto"
 
 # Optional organization/site prefix. Leave empty when no shared prefix is used.
 PANTHEON_SITE_PREFIX=""
 
-# Optional Pantheon tag -> local folder routing.
+# Optional Pantheon Tag -> local directory routing.
 #
 # These examples are intentionally generic. Replace or remove them in your
 # local config. The implementation will fail rather than guess when routing is

--- a/docs/local-provider-architecture.md
+++ b/docs/local-provider-architecture.md
@@ -1,0 +1,94 @@
+# Local Provider Architecture
+
+Pantheon Local Tools separates Pantheon operations from the local development environment used to run a project.
+
+The goal is for commands such as `pantheon-multidev`, `pantheon-pull`, and `pantheon-status` to expose one consistent user workflow while delegating environment-specific details to a provider adapter.
+
+## Why providers
+
+Drupal.org currently recommends DDEV for Drupal local development, while many existing Pantheon projects use Lando. Pantheon also documents DDEV integration with its platform. The tool should not require a team to standardize on one local container stack before it can use the Pantheon workflow helpers.
+
+The shared core therefore owns Pantheon concepts. Provider adapters own local-runtime concepts.
+
+## Shared core responsibilities
+
+The core is responsible for:
+
+- parsing a Pantheon `site.environment` target;
+- querying Terminus for authoritative site and environment information;
+- reading Pantheon Tags and applying user-configured Tag-to-directory mappings;
+- obtaining the authoritative Git connection for an environment;
+- choosing and creating the local destination path;
+- refusing to overwrite an existing checkout;
+- cloning the selected Pantheon environment;
+- selecting a provider without guessing when the result is ambiguous;
+- recording non-secret local state needed by `pantheon-status`;
+- presenting consistent errors and status output.
+
+The core must not assume DDEV or Lando naming, URL, start, rebuild, or data-pull behavior.
+
+## Provider responsibilities
+
+A provider adapter is responsible for local behavior such as:
+
+- detecting whether its project configuration is present;
+- creating local-only configuration for an isolated checkout;
+- calculating or discovering the local project name and URL;
+- starting or restarting the local environment when explicitly requested;
+- pulling/importing database and files through the provider's supported workflow;
+- reporting provider-specific status.
+
+The first providers are:
+
+### DDEV
+
+DDEV projects use `.ddev/config.yaml` and may use local-only `config.*.yaml` overrides such as `.ddev/config.local.yaml`.
+
+Pantheon documents a DDEV provider integration that supports `ddev pull pantheon`. Where the project is configured for that integration, the DDEV adapter should prefer the documented DDEV workflow rather than reimplementing it.
+
+### Lando
+
+Lando projects use `.lando.yml`. Checkout-specific settings can be placed in `.lando.local.yml` and kept outside version control.
+
+The Lando adapter should preserve the project's existing recipe and services while applying only the minimum local overrides needed for an isolated checkout.
+
+## Provider selection
+
+Provider selection follows this precedence:
+
+1. explicit command option (`--provider ddev` or `--provider lando`);
+2. user configuration (`PANTHEON_LOCAL_PROVIDER`);
+3. unambiguous provider configuration found in the project after cloning;
+4. otherwise fail and require an explicit choice.
+
+`auto` is a detection mode, not permission to guess.
+
+If both DDEV and Lando configurations exist, or neither can be identified reliably, the command must stop unless the user supplied a provider explicitly or configured a default.
+
+## Local configuration
+
+User configuration lives outside project repositories, by default at:
+
+```text
+~/.config/pantheon-local-tools/config
+```
+
+The root directory is configurable. The project does not assume `~/lando`, `~/sites/pantheon`, or any organization-specific directory layout.
+
+Pantheon Tag routing is also user-defined. Pantheon Tags are the authoritative source labels; the mapped local directories are only developer-specific destinations.
+
+## Safety rules
+
+- Never overwrite an existing checkout.
+- Never commit machine-specific provider overrides automatically.
+- Never embed Pantheon tokens, SSH keys, credentials, or organization-private values.
+- Never start, rebuild, delete, or otherwise mutate a local runtime as a hidden side effect.
+- Never perform a Pantheon remote write unless the user explicitly requested an operation that requires it.
+- Fail on ambiguous Tag routing or provider selection instead of guessing.
+
+## Upstream references
+
+- Drupal local server setup: https://www.drupal.org/docs/develop/local-server-setup
+- Pantheon DDEV guide: https://docs.pantheon.io/guides/local-development/ddev
+- Pantheon local development guide: https://docs.pantheon.io/guides/local-development
+- DDEV configuration overrides: https://ddev.readthedocs.io/en/stable/users/configuration/config/


### PR DESCRIPTION
## Summary

Generalize Pantheon Local Tools so it does not assume one local development stack.

- make DDEV and Lando first-class planned providers
- keep Pantheon/Terminus behavior in a shared provider-neutral core
- add explicit, fail-safe provider selection semantics
- use provider-local override files instead of committing machine-specific config
- make the default local root provider-neutral
- update public contributor and bug-report guidance
- document the provider boundary and upstream Drupal/Pantheon/DDEV references

## Rationale

Drupal.org currently recommends DDEV for Drupal local development, and Pantheon documents DDEV integration as well as other local development approaches. Existing Pantheon teams may still use Lando, so the tool should support either without hard-coding one environment.

## Validation

- reviewed the branch against `main`
- no organization-specific Pantheon Tags or local directory names introduced
- no implementation behavior changed yet; this establishes the architecture before command implementation
- repository CI should validate the branch
