### PR TITLE
Add Git-style configuration CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,9 +26,10 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Include OS, shell, local provider and version (for example DDEV or Lando), Terminus version, and tool version when known.
+      description: Include OS, shell, WSL distribution/version when applicable, local provider and version, Terminus version, and tool version when known.
       placeholder: |
         OS:
+        WSL distribution/version (if applicable):
         Shell:
         Local provider:
         Provider version:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,46 +11,51 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Install ShellCheck
+      - name: Install ShellCheck on Ubuntu
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install --yes shellcheck
+
+      - name: Install ShellCheck on macOS
+        if: runner.os == 'macOS'
+        run: brew install shellcheck
 
       - name: Validate shell syntax
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t files < <(find . -type f \
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            bash -n "$file"
+          done < <(find . -type f \
             \( -name '*.sh' -o -path './bin/*' \) \
             -not -path './.git/*' \
             -print)
-
-          if ((${#files[@]} == 0)); then
-            echo 'No shell files to validate yet.'
-            exit 0
-          fi
-
-          for file in "${files[@]}"; do
-            bash -n "$file"
-          done
 
       - name: Run ShellCheck
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t files < <(find . -type f \
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            shellcheck "$file"
+          done < <(find . -type f \
             \( -name '*.sh' -o -path './bin/*' \) \
             -not -path './.git/*' \
             -print)
 
-          if ((${#files[@]} == 0)); then
-            echo 'No shell files to lint yet.'
-            exit 0
-          fi
-
-          shellcheck "${files[@]}"
+      - name: Run configuration tests
+        shell: bash
+        run: bash tests/test-config.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,19 @@ Thanks for helping improve Pantheon Local Tools.
 
 ## Development setup
 
-The project targets macOS/Linux shell environments and expects Git, Bash, Terminus, and at least one supported local development provider.
+The command-line tooling targets macOS, Linux, and Windows through WSL/WSL2. Native PowerShell and Command Prompt are not initial targets.
 
-The first supported providers are DDEV and Lando. Changes to shared Pantheon/Terminus behavior should remain provider-neutral; provider-specific behavior belongs behind the provider boundary.
+Development expects Git and Bash. Pantheon workflow integration additionally requires an authenticated Terminus installation and at least one supported local development provider. The first providers are DDEV and Lando.
 
-Until the first stable release, supported versions and installation details may change as integration testing continues.
+Shell code shared across platforms should avoid Bash 4-only features so it remains usable with the older Bash supplied by macOS. WSL code should use Linux paths and must not assume native Windows path syntax.
+
+Pantheon publishes the canonical Terminus setup and authentication guidance:
+
+- https://docs.pantheon.io/terminus/install
+- https://docs.pantheon.io/machine-tokens
+- https://docs.pantheon.io/terminus/commands/auth-login
+
+Never add machine tokens or other credentials to tests, fixtures, documentation examples, or repository configuration.
 
 ## Pull requests
 
@@ -24,7 +32,8 @@ Until the first stable release, supported versions and installation details may 
 4. Run the repository validation commands documented in the README.
 5. Update documentation when user-visible behavior changes.
 6. When changing provider behavior, validate the affected provider and avoid regressions in the other supported provider.
-7. Open a pull request against `main` and explain what changed, why, and how it was tested.
+7. When changing portable shell behavior, consider macOS, Linux, and WSL path/shell semantics.
+8. Open a pull request against `main` and explain what changed, why, and how it was tested.
 
 The repository uses squash merging so each reviewed pull request becomes one canonical integration commit.
 
@@ -33,11 +42,11 @@ The repository uses squash merging so each reviewed pull request becomes one can
 This project interacts with developer environments and Pantheon sites. Changes must fail safely.
 
 - Do not overwrite an existing checkout without explicit user action.
-- Do not embed credentials, tokens, machine-specific paths, organization-specific tags, or private naming conventions.
+- Do not embed credentials, tokens, machine-specific paths, organization-specific Pantheon Tags, or private naming conventions.
 - Treat remote writes, destructive local operations, and environment start/rebuild operations as explicit actions rather than hidden side effects.
-- Prefer Terminus, DDEV, and Lando's documented interfaces over scraping or guessing implementation details.
+- Prefer documented Terminus, DDEV, and Lando interfaces over scraping or guessing implementation details.
 - Do not make shared Pantheon logic depend directly on one local provider.
-- If provider detection is ambiguous, fail and require an explicit provider instead of guessing.
+- If provider detection or Pantheon Tag routing is ambiguous, fail and require an explicit choice instead of guessing.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,129 @@
 # Pantheon Local Tools
 
-Local development helpers for Pantheon workflows across supported local development providers.
+Provider-neutral local development helpers for Pantheon workflows, with DDEV and Lando as the first supported local providers.
 
-This project is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon tags, local directory mappings, or local development stack.
+Pantheon Local Tools is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon Tags, local directory mappings, or local development stack.
 
-## Planned commands
+## Commands
 
-- `pantheon-multidev SITE.ENV` — clone a Pantheon multidev into an isolated local checkout and configure the selected local provider.
-- `pantheon-pull ENV` — refresh database/files for a normal local checkout without changing checked-out code.
-- `pantheon-status` — show the local checkout, selected provider, local URL, Git branch, and recorded Pantheon data source.
+The first implemented command surface is the Git-style configuration interface:
+
+```bash
+pantheon-local config set root ~/sites/pantheon
+pantheon-local config set provider ddev
+pantheon-local config get provider
+pantheon-local config tag set "Client Sites" clients
+pantheon-local config tag list
+pantheon-local config list
+pantheon-local config path
+```
+
+Planned workflow commands are:
+
+- `pantheon-local multidev SITE.ENV` — clone a Pantheon multidev into an isolated local checkout and configure the selected local provider.
+- `pantheon-local pull ENV` — refresh database/files for a normal local checkout without changing checked-out code.
+- `pantheon-local status` — show the local checkout, selected provider, local URL, Git branch, and recorded Pantheon data source.
+
+Convenience wrapper commands may be added after the canonical `pantheon-local` interface is stable.
+
+## Configuration
+
+Users do not need to hand-edit configuration files. `pantheon-local config` reads and writes a Git-compatible configuration file through Git's own parser.
+
+By default the file is stored at:
+
+```text
+~/.config/pantheon-local-tools/config
+```
+
+If `XDG_CONFIG_HOME` is set, that location is respected. `PANTHEON_LOCAL_CONFIG` can override the complete path for automation and testing.
+
+Built-in defaults are:
+
+- `root`: `$HOME/sites/pantheon`
+- `provider`: `auto`
+- `site-prefix`: empty
+- Pantheon Tag mappings: none
+
+Examples:
+
+```bash
+pantheon-local config set root ~/work/pantheon
+pantheon-local config set provider lando
+pantheon-local config set site-prefix example
+pantheon-local config tag set "Internal" internal
+pantheon-local config tag unset "Internal"
+pantheon-local config unset provider
+```
+
+`config unset` removes the stored value and restores the built-in default where one exists. `config.example` documents the underlying file format, but the CLI is the recommended interface.
+
+Organization-specific site prefixes, Pantheon Tags, and local directory names belong only in user configuration and are never project defaults.
+
+## Terminus prerequisite
+
+Pantheon Local Tools expects Terminus to already be installed and authenticated before commands access Pantheon. The tool will detect missing prerequisites and fail with an actionable message rather than attempting to manage Pantheon credentials itself.
+
+Pantheon's official documentation covers both installation and authentication:
+
+- [Install and Update Terminus](https://docs.pantheon.io/terminus/install)
+- [Create and manage machine tokens](https://docs.pantheon.io/machine-tokens)
+- [`terminus auth:login` command reference](https://docs.pantheon.io/terminus/commands/auth-login)
+
+A new Terminus installation generally needs a Pantheon machine token for its first authentication. Follow Pantheon's current instructions rather than storing a token in Pantheon Local Tools configuration. After authentication, `terminus auth:whoami` is a useful way to verify the active Pantheon identity.
 
 ## Local development providers
 
 The first supported providers are **DDEV** and **Lando**.
 
-Drupal.org currently recommends DDEV for Drupal local development, while Pantheon documents both local-development approaches. Pantheon Local Tools therefore keeps Pantheon and Terminus behavior in a shared core and delegates provider-specific behavior to adapters.
+Drupal.org currently recommends DDEV for Drupal local development, while existing Pantheon projects may use either DDEV, Lando, or another local workflow. Pantheon Local Tools therefore keeps Pantheon and Terminus behavior in a shared core and delegates provider-specific behavior to adapters.
 
-Provider selection is designed to be explicit and fail-safe. The implementation will resolve the provider in this order:
+Provider selection is designed to be explicit and fail-safe. Planned workflow commands resolve the provider in this order:
 
 1. an explicit command option such as `--provider ddev` or `--provider lando`;
 2. the user's configured default provider;
 3. an unambiguous provider configuration already present in the cloned project;
 4. otherwise, fail and ask the user to choose rather than guessing.
 
-Provider-specific local configuration must remain local to the developer's checkout. DDEV supports local `config.*.yaml` overrides such as `.ddev/config.local.yaml`; Lando checkouts can use `.lando.local.yml` for local overrides.
-
-## Design goals
-
-- Use Terminus as the authoritative source for Pantheon site/environment data.
-- Keep Pantheon operations independent from the developer's local container provider.
-- Keep local filesystem roots configurable per developer.
-- Allow optional Pantheon tag-to-local-directory routing through user configuration.
-- Keep all organization-specific prefixes, Pantheon tags, local directory mappings, and provider preferences in user configuration rather than source code.
-- Configure isolated local names and URLs without committing machine-specific overrides to the Pantheon site repository.
-- Never overwrite an existing checkout or silently choose between ambiguous providers.
-- Treat environment start/rebuild operations and remote writes as explicit actions.
-
-For example, one organization might map a Pantheon tag such as `Agency` to a local `agency/` directory while another developer may use no tag routing at all. One developer may use DDEV while another uses Lando. Those choices belong in each developer's local configuration and are not project defaults.
+Provider-specific local configuration remains local to the developer's checkout. DDEV supports local `config.*.yaml` overrides such as `.ddev/config.local.yaml`; Lando checkouts can use `.lando.local.yml` for local overrides.
 
 See [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) for the provider boundary and upstream references.
 
-## Status
+## Supported host environments
 
-Early development. The first implementation is being validated against real Pantheon and Terminus environments with both DDEV and Lando provider behavior before the initial release.
+The command-line tooling targets:
 
-## Requirements
+- macOS;
+- Linux; and
+- Windows through WSL/WSL2.
 
-The initial implementation targets macOS/Linux shells and expects:
+On Windows, commands run inside the WSL Linux environment and use Linux paths. Native PowerShell and Command Prompt are not initial targets. The selected local provider must also be installed in a supported configuration for that host environment.
 
-- Git
-- Bash
-- Terminus
-- at least one supported local provider: DDEV or Lando
+The shipped shell code intentionally avoids Bash 4-only features so it remains compatible with the older Bash supplied by macOS as well as modern Bash on Linux and WSL.
 
-Exact supported versions will be documented after integration testing.
+## Install from a clone
+
+```bash
+git clone git@github.com:zevarix/pantheon-local-tools.git
+cd pantheon-local-tools
+./install.sh
+```
+
+The installer creates a symlink at `~/.local/bin/pantheon-local` by default and refuses to overwrite an unrelated existing command. Set `PANTHEON_LOCAL_BIN_DIR` to choose a different destination.
+
+## Development
+
+Run the config tests directly:
+
+```bash
+bash tests/test-config.sh
+```
+
+Run ShellCheck when available:
+
+```bash
+shellcheck bin/pantheon-local install.sh tests/test-config.sh
+```
 
 ## Contributing
 

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -79,15 +79,15 @@ default_value() {
 }
 
 expand_home() {
-  local value=$1
+  local value=$1 tilde='~'
   case "$value" in
-    '~')
+    "$tilde")
       [ -n "${HOME:-}" ] || die 'HOME is not set; cannot expand ~'
       printf '%s\n' "$HOME"
       ;;
-    '~/'*)
+    "$tilde"/*)
       [ -n "${HOME:-}" ] || die 'HOME is not set; cannot expand ~/'
-      printf '%s/%s\n' "${HOME%/}" "${value#\~/}"
+      printf '%s/%s\n' "${HOME%/}" "${value#*/}"
       ;;
     *) printf '%s\n' "$value" ;;
   esac

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME="pantheon-local"
+DEFAULT_PROVIDER="auto"
+DEFAULT_ROOT_SUFFIX="sites/pantheon"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  pantheon-local config path
+  pantheon-local config get KEY
+  pantheon-local config set KEY VALUE
+  pantheon-local config unset KEY
+  pantheon-local config list
+  pantheon-local config tag get TAG
+  pantheon-local config tag set TAG DIRECTORY
+  pantheon-local config tag unset TAG
+  pantheon-local config tag list
+
+Configuration keys:
+  root         Absolute local root for Pantheon checkouts.
+  provider     auto, ddev, or lando.
+  site-prefix  Optional organization/site prefix.
+USAGE
+}
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+config_path() {
+  if [ -n "${PANTHEON_LOCAL_CONFIG:-}" ]; then
+    printf '%s\n' "$PANTHEON_LOCAL_CONFIG"
+    return
+  fi
+
+  if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    printf '%s/pantheon-local-tools/config\n' "${XDG_CONFIG_HOME%/}"
+    return
+  fi
+
+  [ -n "${HOME:-}" ] || die 'HOME is not set; set PANTHEON_LOCAL_CONFIG explicitly'
+  printf '%s/.config/pantheon-local-tools/config\n' "${HOME%/}"
+}
+
+ensure_config_parent() {
+  local file parent
+  file=$(config_path)
+  parent=${file%/*}
+  [ "$parent" != "$file" ] || parent='.'
+  mkdir -p "$parent"
+}
+
+key_to_git_key() {
+  case "$1" in
+    root) printf '%s\n' 'local.root' ;;
+    provider) printf '%s\n' 'local.provider' ;;
+    site-prefix) printf '%s\n' 'pantheon.sitePrefix' ;;
+    *) die "unknown configuration key: $1" ;;
+  esac
+}
+
+default_value() {
+  case "$1" in
+    root)
+      [ -n "${HOME:-}" ] || return 1
+      printf '%s/%s\n' "${HOME%/}" "$DEFAULT_ROOT_SUFFIX"
+      ;;
+    provider) printf '%s\n' "$DEFAULT_PROVIDER" ;;
+    site-prefix) printf '\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+expand_home() {
+  local value=$1
+  case "$value" in
+    '~')
+      [ -n "${HOME:-}" ] || die 'HOME is not set; cannot expand ~'
+      printf '%s\n' "$HOME"
+      ;;
+    '~/'*)
+      [ -n "${HOME:-}" ] || die 'HOME is not set; cannot expand ~/'
+      printf '%s/%s\n' "${HOME%/}" "${value#\~/}"
+      ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
+validate_value() {
+  local key=$1 value=$2
+  case "$key" in
+    root)
+      [ -n "$value" ] || die 'root cannot be empty'
+      case "$value" in
+        *$'\n'*|*$'\r'*) die 'root cannot contain newlines' ;;
+        [A-Za-z]:\\*|[A-Za-z]:/*) die 'use a Linux path under WSL (for example /mnt/c/...) instead of a native Windows path' ;;
+        /*) ;;
+        *) die 'root must be an absolute path or start with ~/' ;;
+      esac
+      ;;
+    provider)
+      case "$value" in auto|ddev|lando) ;; *) die 'provider must be one of: auto, ddev, lando' ;; esac
+      ;;
+    site-prefix)
+      case "$value" in *$'\n'*|*$'\r'*) die 'site-prefix cannot contain newlines' ;; esac
+      ;;
+  esac
+}
+
+validate_tag() {
+  local tag=$1
+  [ -n "$tag" ] || die 'Pantheon Tag cannot be empty'
+  printf '%s\n' "$tag" | LC_ALL=C grep -Eq '^[A-Za-z0-9][A-Za-z0-9._ -]*$' || \
+    die 'Pantheon Tag may contain letters, numbers, spaces, dot, underscore, and hyphen'
+}
+
+validate_tag_directory() {
+  local directory=$1 wrapped
+  [ -n "$directory" ] || die 'tag directory cannot be empty'
+  case "$directory" in
+    /*) die 'tag directory must be relative to the configured root' ;;
+    *\\*) die 'tag directory must use forward slashes (including under WSL)' ;;
+    *$'\n'*|*$'\r'*) die 'tag directory cannot contain newlines' ;;
+    *'//'*) die 'tag directory cannot contain empty path segments' ;;
+  esac
+  wrapped="/$directory/"
+  case "$wrapped" in
+    */./*|*/../*) die 'tag directory cannot contain . or .. path segments' ;;
+  esac
+}
+
+config_get_raw() {
+  local git_key=$1 file
+  file=$(config_path)
+  [ -f "$file" ] || return 1
+  git config --file "$file" --get "$git_key"
+}
+
+config_get() {
+  local key=$1 git_key value
+  require_command git
+  git_key=$(key_to_git_key "$key")
+  if value=$(config_get_raw "$git_key" 2>/dev/null); then
+    if [ "$key" = 'root' ]; then
+      value=$(expand_home "$value")
+      validate_value root "$value"
+    fi
+    printf '%s\n' "$value"
+  else
+    default_value "$key"
+  fi
+}
+
+config_set() {
+  local key=$1 value=$2 git_key file
+  require_command git
+  git_key=$(key_to_git_key "$key")
+  if [ "$key" = 'root' ]; then
+    value=$(expand_home "$value")
+  fi
+  validate_value "$key" "$value"
+  ensure_config_parent
+  file=$(config_path)
+  git config --file "$file" --replace-all "$git_key" "$value"
+}
+
+config_unset() {
+  local key=$1 git_key file
+  require_command git
+  git_key=$(key_to_git_key "$key")
+  file=$(config_path)
+  [ -f "$file" ] || return 0
+  git config --file "$file" --unset-all "$git_key" >/dev/null 2>&1 || true
+}
+
+tag_git_key() {
+  printf 'tag.%s.directory\n' "$1"
+}
+
+tag_get() {
+  local tag=$1 file key
+  require_command git
+  validate_tag "$tag"
+  file=$(config_path)
+  key=$(tag_git_key "$tag")
+  [ -f "$file" ] || die "no directory mapping configured for Pantheon Tag: $tag"
+  git config --file "$file" --get "$key" || die "no directory mapping configured for Pantheon Tag: $tag"
+}
+
+tag_set() {
+  local tag=$1 directory=$2 file key
+  require_command git
+  validate_tag "$tag"
+  validate_tag_directory "$directory"
+  ensure_config_parent
+  file=$(config_path)
+  key=$(tag_git_key "$tag")
+  git config --file "$file" --replace-all "$key" "$directory"
+}
+
+tag_unset() {
+  local tag=$1 file key
+  require_command git
+  validate_tag "$tag"
+  file=$(config_path)
+  [ -f "$file" ] || return 0
+  key=$(tag_git_key "$tag")
+  git config --file "$file" --unset-all "$key" >/dev/null 2>&1 || true
+}
+
+tag_list() {
+  local file key tag value
+  require_command git
+  file=$(config_path)
+  [ -f "$file" ] || return 0
+
+  { git config --file "$file" --name-only --get-regexp '^tag\..*\.directory$' 2>/dev/null || true; } | while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    tag=${key#tag.}
+    tag=${tag%.directory}
+    value=$(git config --file "$file" --get "$key")
+    printf '%s=%s\n' "$tag" "$value"
+  done
+}
+
+config_list() {
+  printf 'root=%s\n' "$(config_get root)"
+  printf 'provider=%s\n' "$(config_get provider)"
+  printf 'site-prefix=%s\n' "$(config_get site-prefix)"
+  tag_list | while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    printf 'tag.%s\n' "$line"
+  done
+}
+
+config_command() {
+  local action=${1:-}
+  case "$action" in
+    path)
+      [ "$#" -eq 1 ] || die 'usage: pantheon-local config path'
+      config_path
+      ;;
+    get)
+      [ "$#" -eq 2 ] || die 'usage: pantheon-local config get KEY'
+      config_get "$2"
+      ;;
+    set)
+      [ "$#" -eq 3 ] || die 'usage: pantheon-local config set KEY VALUE'
+      config_set "$2" "$3"
+      ;;
+    unset)
+      [ "$#" -eq 2 ] || die 'usage: pantheon-local config unset KEY'
+      config_unset "$2"
+      ;;
+    list)
+      [ "$#" -eq 1 ] || die 'usage: pantheon-local config list'
+      config_list
+      ;;
+    tag)
+      shift
+      tag_command "$@"
+      ;;
+    ''|-h|--help|help) usage ;;
+    *) die "unknown config command: $action" ;;
+  esac
+}
+
+tag_command() {
+  local action=${1:-}
+  case "$action" in
+    get)
+      [ "$#" -eq 2 ] || die 'usage: pantheon-local config tag get TAG'
+      tag_get "$2"
+      ;;
+    set)
+      [ "$#" -eq 3 ] || die 'usage: pantheon-local config tag set TAG DIRECTORY'
+      tag_set "$2" "$3"
+      ;;
+    unset)
+      [ "$#" -eq 2 ] || die 'usage: pantheon-local config tag unset TAG'
+      tag_unset "$2"
+      ;;
+    list)
+      [ "$#" -eq 1 ] || die 'usage: pantheon-local config tag list'
+      tag_list
+      ;;
+    ''|-h|--help|help) usage ;;
+    *) die "unknown config tag command: $action" ;;
+  esac
+}
+
+main() {
+  local command=${1:-}
+  case "$command" in
+    config)
+      shift
+      config_command "$@"
+      ;;
+    -h|--help|help|'') usage ;;
+    *) die "unknown command: $command" ;;
+  esac
+}
+
+main "$@"

--- a/config.example
+++ b/config.example
@@ -1,30 +1,23 @@
-# Pantheon Local Tools user configuration example
+# Pantheon Local Tools configuration example
 #
-# Copy this file to:
+# This file documents the Git-compatible configuration format used by
+# `pantheon-local config`. Users normally do not need to edit it by hand.
+#
+# Default location:
 #   ~/.config/pantheon-local-tools/config
 #
-# Machine- and organization-specific values belong in the user config, not
-# in this repository.
+# All values below are generic examples only. Organization-specific Pantheon
+# Tags, prefixes, and directory names belong in each user's local config.
 
-# Root directory under which local Pantheon projects are organized.
-# Override this with any layout that works for your machine.
-PANTHEON_LOCAL_ROOT="$HOME/sites/pantheon"
+[local]
+    root = ~/sites/pantheon
+    provider = auto
 
-# Local development provider.
-# Supported planned values: auto, ddev, lando
-# "auto" uses an unambiguous project configuration when one is present and
-# otherwise requires an explicit choice rather than guessing.
-PANTHEON_LOCAL_PROVIDER="auto"
+[pantheon]
+    sitePrefix =
 
-# Optional organization/site prefix. Leave empty when no shared prefix is used.
-PANTHEON_SITE_PREFIX=""
+[tag "Example Group"]
+    directory = example-group
 
-# Optional Pantheon Tag -> local directory routing.
-#
-# These examples are intentionally generic. Replace or remove them in your
-# local config. The implementation will fail rather than guess when routing is
-# ambiguous.
-declare -A PANTHEON_TAG_ROUTES=(
-  ["ExampleGroup"]="example-group"
-  ["AnotherGroup"]="another-group"
-)
+[tag "Another Group"]
+    directory = another-group

--- a/docs/local-provider-architecture.md
+++ b/docs/local-provider-architecture.md
@@ -2,7 +2,19 @@
 
 Pantheon Local Tools separates Pantheon operations from the local development environment used to run a project.
 
-The goal is for commands such as `pantheon-multidev`, `pantheon-pull`, and `pantheon-status` to expose one consistent user workflow while delegating environment-specific details to a provider adapter.
+The canonical CLI is `pantheon-local`. Commands such as `pantheon-local multidev`, `pantheon-local pull`, and `pantheon-local status` expose one consistent user workflow while delegating environment-specific details to a provider adapter.
+
+## Host environments
+
+The shell tooling targets:
+
+- macOS;
+- Linux; and
+- Windows through WSL/WSL2.
+
+Native PowerShell and Command Prompt are not initial targets. WSL is treated as a Linux execution environment: commands use Linux paths such as `/home/user/...` or `/mnt/c/...`, not `C:\...` paths.
+
+Portable shell code avoids Bash 4-only features so the same core can run under the older Bash shipped by macOS and modern Bash on Linux/WSL.
 
 ## Why providers
 
@@ -15,6 +27,7 @@ The shared core therefore owns Pantheon concepts. Provider adapters own local-ru
 The core is responsible for:
 
 - parsing a Pantheon `site.environment` target;
+- verifying required commands and Terminus authentication before Pantheon operations;
 - querying Terminus for authoritative site and environment information;
 - reading Pantheon Tags and applying user-configured Tag-to-directory mappings;
 - obtaining the authoritative Git connection for an environment;
@@ -22,10 +35,22 @@ The core is responsible for:
 - refusing to overwrite an existing checkout;
 - cloning the selected Pantheon environment;
 - selecting a provider without guessing when the result is ambiguous;
-- recording non-secret local state needed by `pantheon-status`;
+- recording non-secret local state needed by status output;
 - presenting consistent errors and status output.
 
 The core must not assume DDEV or Lando naming, URL, start, rebuild, or data-pull behavior.
+
+## Terminus authentication boundary
+
+Pantheon Local Tools does not own or store Pantheon credentials. Users authenticate Terminus using Pantheon's supported workflow before running commands that query Pantheon.
+
+The tool should preflight Terminus and provide an actionable error when authentication is missing. It must never prompt for, persist, echo, or copy a Pantheon machine token into Pantheon Local Tools configuration.
+
+Pantheon's canonical references are:
+
+- https://docs.pantheon.io/terminus/install
+- https://docs.pantheon.io/machine-tokens
+- https://docs.pantheon.io/terminus/commands/auth-login
 
 ## Provider responsibilities
 
@@ -57,7 +82,7 @@ The Lando adapter should preserve the project's existing recipe and services whi
 Provider selection follows this precedence:
 
 1. explicit command option (`--provider ddev` or `--provider lando`);
-2. user configuration (`PANTHEON_LOCAL_PROVIDER`);
+2. user configuration (`local.provider`);
 3. unambiguous provider configuration found in the project after cloning;
 4. otherwise fail and require an explicit choice.
 
@@ -65,12 +90,20 @@ Provider selection follows this precedence:
 
 If both DDEV and Lando configurations exist, or neither can be identified reliably, the command must stop unless the user supplied a provider explicitly or configured a default.
 
-## Local configuration
+## Git-style local configuration
 
 User configuration lives outside project repositories, by default at:
 
 ```text
 ~/.config/pantheon-local-tools/config
+```
+
+The file uses Git's config format and is read/written through Git itself. Users normally manage it through commands such as:
+
+```bash
+pantheon-local config set root ~/sites/pantheon
+pantheon-local config set provider ddev
+pantheon-local config tag set "Client Sites" clients
 ```
 
 The root directory is configurable. The project does not assume `~/lando`, `~/sites/pantheon`, or any organization-specific directory layout.
@@ -82,13 +115,18 @@ Pantheon Tag routing is also user-defined. Pantheon Tags are the authoritative s
 - Never overwrite an existing checkout.
 - Never commit machine-specific provider overrides automatically.
 - Never embed Pantheon tokens, SSH keys, credentials, or organization-private values.
+- Never store executable shell code as user configuration.
 - Never start, rebuild, delete, or otherwise mutate a local runtime as a hidden side effect.
 - Never perform a Pantheon remote write unless the user explicitly requested an operation that requires it.
-- Fail on ambiguous Tag routing or provider selection instead of guessing.
+- Fail on ambiguous Pantheon Tag routing or provider selection instead of guessing.
+- Under WSL, use Linux path semantics and reject native Windows path syntax where it would be unsafe or ambiguous.
 
 ## Upstream references
 
 - Drupal local server setup: https://www.drupal.org/docs/develop/local-server-setup
+- Pantheon Terminus install/authentication: https://docs.pantheon.io/terminus/install
+- Pantheon machine tokens: https://docs.pantheon.io/machine-tokens
+- Pantheon `auth:login`: https://docs.pantheon.io/terminus/commands/auth-login
 - Pantheon DDEV guide: https://docs.pantheon.io/guides/local-development/ddev
 - Pantheon local development guide: https://docs.pantheon.io/guides/local-development
 - DDEV configuration overrides: https://ddev.readthedocs.io/en/stable/users/configuration/config/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME="pantheon-local-tools installer"
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+[ -n "${HOME:-}" ] || die 'HOME is not set'
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SOURCE="$SCRIPT_DIR/bin/pantheon-local"
+BIN_DIR=${PANTHEON_LOCAL_BIN_DIR:-"$HOME/.local/bin"}
+DESTINATION="$BIN_DIR/pantheon-local"
+
+[ -f "$SOURCE" ] || die "command not found in repository: $SOURCE"
+mkdir -p "$BIN_DIR"
+
+if [ -L "$DESTINATION" ]; then
+  CURRENT_TARGET=$(readlink "$DESTINATION" || true)
+  [ "$CURRENT_TARGET" = "$SOURCE" ] || die "refusing to replace existing symlink: $DESTINATION"
+elif [ -e "$DESTINATION" ]; then
+  die "refusing to replace existing path: $DESTINATION"
+else
+  ln -s "$SOURCE" "$DESTINATION"
+fi
+
+printf 'Installed pantheon-local -> %s\n' "$SOURCE"
+printf 'Command path: %s\n' "$DESTINATION"
+
+case ":${PATH:-}:" in
+  *":$BIN_DIR:"*) ;;
+  *) printf 'Add %s to PATH to run pantheon-local from any directory.\n' "$BIN_DIR" ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ die() {
 
 [ -n "${HOME:-}" ] || die 'HOME is not set'
 
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 SOURCE="$SCRIPT_DIR/bin/pantheon-local"
 BIN_DIR=${PANTHEON_LOCAL_BIN_DIR:-"$HOME/.local/bin"}
 DESTINATION="$BIN_DIR/pantheon-local"

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CLI=${CLI:-"$REPO_ROOT/bin/pantheon-local"}
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+export HOME="$TMP_ROOT/home"
+export PANTHEON_LOCAL_CONFIG="$TMP_ROOT/config/pantheon-local-tools/config"
+mkdir -p "$HOME"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
+
+# The documented example must remain valid Git config data, not executable shell.
+assert_eq "$(git config --file "$REPO_ROOT/config.example" --get local.provider)" 'auto'
+if grep -Eq '(^|[[:space:]])(declare|source|eval)[[:space:]]' "$REPO_ROOT/config.example"; then
+  fail 'config.example contains executable shell syntax'
+fi
+
+assert_eq "$(bash "$CLI" config path)" "$PANTHEON_LOCAL_CONFIG"
+assert_eq "$(bash "$CLI" config get provider)" 'auto'
+assert_eq "$(bash "$CLI" config get root)" "$HOME/sites/pantheon"
+
+bash "$CLI" config set root '~/Pantheon Sites'
+assert_eq "$(bash "$CLI" config get root)" "$HOME/Pantheon Sites"
+
+# WSL uses Linux paths; /mnt/<drive>/... is accepted while native Windows paths are rejected.
+bash "$CLI" config set root '/mnt/c/Users/example/Pantheon Sites'
+assert_eq "$(bash "$CLI" config get root)" '/mnt/c/Users/example/Pantheon Sites'
+if bash "$CLI" config set root 'C:\Users\example\Pantheon' >/dev/null 2>&1; then
+  fail 'native Windows root path was accepted'
+fi
+if bash "$CLI" config set root 'relative/path' >/dev/null 2>&1; then
+  fail 'relative root path was accepted'
+fi
+
+bash "$CLI" config set root "$HOME/Pantheon Sites"
+bash "$CLI" config set provider lando
+assert_eq "$(bash "$CLI" config get provider)" 'lando'
+if bash "$CLI" config set provider nope >/dev/null 2>&1; then fail 'invalid provider was accepted'; fi
+
+bash "$CLI" config set site-prefix example
+assert_eq "$(bash "$CLI" config get site-prefix)" 'example'
+
+bash "$CLI" config tag set 'Client Sites.v2' 'clients/main'
+assert_eq "$(bash "$CLI" config tag get 'Client Sites.v2')" 'clients/main'
+assert_contains "$(bash "$CLI" config tag list)" 'Client Sites.v2=clients/main'
+
+if bash "$CLI" config tag set Unsafe '/absolute/path' >/dev/null 2>&1; then fail 'absolute tag directory was accepted'; fi
+if bash "$CLI" config tag set Unsafe '../escape' >/dev/null 2>&1; then fail '.. tag directory was accepted'; fi
+if bash "$CLI" config tag set Unsafe 'foo\\bar' >/dev/null 2>&1; then fail 'backslash tag directory was accepted'; fi
+
+output=$(bash "$CLI" config list)
+assert_contains "$output" "root=$HOME/Pantheon Sites"
+assert_contains "$output" 'provider=lando'
+assert_contains "$output" 'site-prefix=example'
+assert_contains "$output" 'tag.Client Sites.v2=clients/main'
+
+bash "$CLI" config unset provider
+assert_eq "$(bash "$CLI" config get provider)" 'auto'
+bash "$CLI" config tag unset 'Client Sites.v2'
+assert_eq "$(bash "$CLI" config tag list)" ''
+
+printf 'config tests passed\n'

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
 CLI=${CLI:-"$REPO_ROOT/bin/pantheon-local"}
 TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
@@ -23,7 +23,8 @@ assert_eq "$(bash "$CLI" config path)" "$PANTHEON_LOCAL_CONFIG"
 assert_eq "$(bash "$CLI" config get provider)" 'auto'
 assert_eq "$(bash "$CLI" config get root)" "$HOME/sites/pantheon"
 
-bash "$CLI" config set root '~/Pantheon Sites'
+tilde='~'
+bash "$CLI" config set root "$tilde/Pantheon Sites"
 assert_eq "$(bash "$CLI" config get root)" "$HOME/Pantheon Sites"
 
 # WSL uses Linux paths; /mnt/<drive>/... is accepted while native Windows paths are rejected.


### PR DESCRIPTION
## Summary

Add the first executable Pantheon Local Tools command surface: a Git-style configuration CLI.

- add canonical `pantheon-local config` commands for get/set/unset/list/path
- add Pantheon Tag mapping commands under `pantheon-local config tag`
- store configuration as non-executable Git config data using Git's own parser
- add a conservative installer that symlinks `pantheon-local` into a configurable bin directory
- target macOS, Linux, and Windows through WSL/WSL2
- reject native Windows paths where WSL requires Linux path semantics
- add macOS + Linux CI and portable Bash tests
- document DDEV/Lando provider-neutral architecture
- link Pantheon's official Terminus install, machine-token, and `auth:login` documentation
- keep Pantheon authentication outside this tool; no machine tokens are stored by Pantheon Local Tools

## Configuration examples

```bash
pantheon-local config set root ~/sites/pantheon
pantheon-local config set provider ddev
pantheon-local config tag set "Client Sites" clients
pantheon-local config list
```

## Validation

- branch is one commit ahead of `main`
- config examples contain data only, not sourced/executable shell
- no organization-specific Pantheon Tags, prefixes, or local directory mappings are included
- CI validates Bash syntax, ShellCheck, and config behavior on Ubuntu and macOS
- WSL path behavior is covered by contract tests using Linux `/mnt/<drive>/...` semantics; a real WSL integration pass will be performed before the first release

## Security

Pantheon Local Tools does not accept, store, or manage Pantheon machine tokens. Users authenticate Terminus through Pantheon's supported workflow before running Pantheon operations.