### PR TITLE
Implement multidev checkout workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -56,6 +56,10 @@ jobs:
             -not -path './.git/*' \
             -print)
 
-      - name: Run configuration tests
+      - name: Run tests
         shell: bash
-        run: bash tests/test-config.sh
+        run: |
+          set -euo pipefail
+          for test in tests/test-*.sh; do
+            bash "$test"
+          done

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Provider-neutral local development helpers for Pantheon workflows, with DDEV and
 
 Pantheon Local Tools is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon Tags, local directory mappings, or local development stack.
 
+The initial release is being validated against Drupal projects. The shared Pantheon/Terminus core stays framework-neutral where doing so does not weaken safety or validation.
+
 ## Commands
 
-The first implemented command surface is the Git-style configuration interface:
+Implemented command surfaces are:
 
 ```bash
 pantheon-local config set root ~/sites/pantheon
@@ -16,11 +18,15 @@ pantheon-local config tag set "Client Sites" clients
 pantheon-local config tag list
 pantheon-local config list
 pantheon-local config path
+
+pantheon-local multidev SITE.ENV
+pantheon-local multidev SITE.ENV --dry-run
+pantheon-local multidev SITE.ENV --provider lando --group migration
+pantheon-local multidev SITE.ENV --provider ddev --start
 ```
 
 Planned workflow commands are:
 
-- `pantheon-local multidev SITE.ENV` — clone a Pantheon multidev into an isolated local checkout and configure the selected local provider.
 - `pantheon-local pull ENV` — refresh database/files for a normal local checkout without changing checked-out code.
 - `pantheon-local status` — show the local checkout, selected provider, local URL, Git branch, and recorded Pantheon data source.
 
@@ -42,7 +48,6 @@ Built-in defaults are:
 
 - `root`: `$HOME/sites/pantheon`
 - `provider`: `auto`
-- `site-prefix`: empty
 - Pantheon Tag mappings: none
 
 Examples:
@@ -50,7 +55,6 @@ Examples:
 ```bash
 pantheon-local config set root ~/work/pantheon
 pantheon-local config set provider lando
-pantheon-local config set site-prefix example
 pantheon-local config tag set "Internal" internal
 pantheon-local config tag unset "Internal"
 pantheon-local config unset provider
@@ -58,11 +62,48 @@ pantheon-local config unset provider
 
 `config unset` removes the stored value and restores the built-in default where one exists. `config.example` documents the underlying file format, but the CLI is the recommended interface.
 
-Organization-specific site prefixes, Pantheon Tags, and local directory names belong only in user configuration and are never project defaults.
+Organization-specific Pantheon Tags and local directory names belong only in user configuration and are never project defaults.
+
+## Multidev checkouts
+
+`pantheon-local multidev SITE.ENV` clones an **existing** Pantheon multidev environment into an isolated local checkout. It does not create, delete, or mutate the remote Pantheon environment.
+
+The command:
+
+1. verifies Terminus authentication;
+2. resolves user-configured Pantheon Tag routing;
+3. gets the authoritative Git URL from Terminus;
+4. refuses to overwrite an existing destination;
+5. clones into a temporary sibling checkout;
+6. selects DDEV or Lando explicitly/configurably, failing on ambiguity;
+7. writes only local provider overrides and records local state under `.git/`; and
+8. finalizes the checkout only after local configuration succeeds.
+
+`--dry-run` performs the read-only Pantheon lookups and prints the resolved plan without cloning or creating directories. `--start` is explicit; the tool never silently starts or rebuilds a local runtime.
+
+With no configured Pantheon Tag routes, checkouts live below:
+
+```text
+<root>/multidev/<site>-<env>
+```
+
+With a Tag route such as `Client Sites -> clients`, the same checkout lives below:
+
+```text
+<root>/clients/multidev/<site>-<env>
+```
+
+Optional grouping adds one safe path segment:
+
+```bash
+pantheon-local multidev SITE.ENV --group migration
+```
+
+See [`docs/multidev.md`](docs/multidev.md) for the full safety and provider behavior contract.
 
 ## Terminus prerequisite
 
-Pantheon Local Tools expects Terminus to already be installed and authenticated before commands access Pantheon. The tool will detect missing prerequisites and fail with an actionable message rather than attempting to manage Pantheon credentials itself.
+Pantheon Local Tools expects Terminus to already be installed and authenticated before commands access Pantheon. The tool detects missing authentication and fails with an actionable message rather than attempting to manage Pantheon credentials itself.
 
 Pantheon's official documentation covers both installation and authentication:
 
@@ -76,16 +117,18 @@ A new Terminus installation generally needs a Pantheon machine token for its fir
 
 The first supported providers are **DDEV** and **Lando**.
 
-Drupal.org currently recommends DDEV for Drupal local development, while existing Pantheon projects may use either DDEV, Lando, or another local workflow. Pantheon Local Tools therefore keeps Pantheon and Terminus behavior in a shared core and delegates provider-specific behavior to adapters.
+Drupal.org recommends DDEV for Drupal local development, while existing Pantheon projects may use either DDEV or Lando. Pantheon Local Tools therefore keeps Pantheon and Terminus behavior in a shared core and delegates local-runtime behavior to provider-specific code.
 
-Provider selection is designed to be explicit and fail-safe. Planned workflow commands resolve the provider in this order:
+Provider selection follows this order:
 
-1. an explicit command option such as `--provider ddev` or `--provider lando`;
+1. an explicit `--provider ddev` or `--provider lando` option;
 2. the user's configured default provider;
-3. an unambiguous provider configuration already present in the cloned project;
-4. otherwise, fail and ask the user to choose rather than guessing.
+3. when configuration is `auto`, unambiguous provider configuration found in the cloned project;
+4. otherwise fail and ask the user to choose rather than guessing.
 
-Provider-specific local configuration remains local to the developer's checkout. DDEV supports local `config.*.yaml` overrides such as `.ddev/config.local.yaml`; Lando checkouts can use `.lando.local.yml` for local overrides.
+For multidev, DDEV requires an existing `.ddev/config.yaml` and receives a local `.ddev/config.local.yaml` name override. Lando requires an existing `.lando.yml` and receives a local `.lando.local.yml` name override; Drupal Lando projects also receive an isolated `DRUSH_OPTIONS_URI`.
+
+Generated provider overrides are added to the checkout's `.git/info/exclude`; the project's shared `.gitignore` is not modified.
 
 See [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) for the provider boundary and upstream references.
 
@@ -111,19 +154,25 @@ cd pantheon-local-tools
 
 The installer creates a symlink at `~/.local/bin/pantheon-local` by default and refuses to overwrite an unrelated existing command. Set `PANTHEON_LOCAL_BIN_DIR` to choose a different destination.
 
+A Homebrew installation path is planned for the first shareable tagged release. The clone installer remains the portable fallback for macOS, Linux, WSL, contributors, and CI.
+
 ## Development
 
-Run the config tests directly:
+Run the test suite directly:
 
 ```bash
-bash tests/test-config.sh
+for test in tests/test-*.sh; do
+  bash "$test"
+done
 ```
 
 Run ShellCheck when available:
 
 ```bash
-shellcheck bin/pantheon-local install.sh tests/test-config.sh
+shellcheck bin/pantheon-local install.sh tests/test-*.sh
 ```
+
+CI runs syntax validation, ShellCheck, and the test suite on both Ubuntu and macOS. WSL behavior is covered by Linux-path contract tests and will receive a real WSL integration pass before the first tagged release.
 
 ## Contributing
 

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -4,6 +4,7 @@ set -euo pipefail
 PROGRAM_NAME="pantheon-local"
 DEFAULT_PROVIDER="auto"
 DEFAULT_ROOT_SUFFIX="sites/pantheon"
+MULTIDEV_TEMP=''
 
 usage() {
   cat <<'USAGE'
@@ -17,11 +18,11 @@ Usage:
   pantheon-local config tag set TAG DIRECTORY
   pantheon-local config tag unset TAG
   pantheon-local config tag list
+  pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]
 
 Configuration keys:
-  root         Absolute local root for Pantheon checkouts.
-  provider     auto, ddev, or lando.
-  site-prefix  Optional organization/site prefix.
+  root      Absolute local root for Pantheon checkouts.
+  provider  auto, ddev, or lando.
 USAGE
 }
 
@@ -61,7 +62,6 @@ key_to_git_key() {
   case "$1" in
     root) printf '%s\n' 'local.root' ;;
     provider) printf '%s\n' 'local.provider' ;;
-    site-prefix) printf '%s\n' 'pantheon.sitePrefix' ;;
     *) die "unknown configuration key: $1" ;;
   esac
 }
@@ -73,7 +73,6 @@ default_value() {
       printf '%s/%s\n' "${HOME%/}" "$DEFAULT_ROOT_SUFFIX"
       ;;
     provider) printf '%s\n' "$DEFAULT_PROVIDER" ;;
-    site-prefix) printf '\n' ;;
     *) return 1 ;;
   esac
 }
@@ -108,9 +107,6 @@ validate_value() {
     provider)
       case "$value" in auto|ddev|lando) ;; *) die 'provider must be one of: auto, ddev, lando' ;; esac
       ;;
-    site-prefix)
-      case "$value" in *$'\n'*|*$'\r'*) die 'site-prefix cannot contain newlines' ;; esac
-      ;;
   esac
 }
 
@@ -134,6 +130,13 @@ validate_tag_directory() {
   case "$wrapped" in
     */./*|*/../*) die 'tag directory cannot contain . or .. path segments' ;;
   esac
+}
+
+validate_group() {
+  local group=$1
+  [ -n "$group" ] || die 'group cannot be empty'
+  printf '%s\n' "$group" | LC_ALL=C grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$' || \
+    die 'group may contain letters, numbers, dot, underscore, and hyphen'
 }
 
 config_get_raw() {
@@ -233,7 +236,6 @@ tag_list() {
 config_list() {
   printf 'root=%s\n' "$(config_get root)"
   printf 'provider=%s\n' "$(config_get provider)"
-  printf 'site-prefix=%s\n' "$(config_get site-prefix)"
   tag_list | while IFS= read -r line; do
     [ -n "$line" ] || continue
     printf 'tag.%s\n' "$line"
@@ -296,12 +298,341 @@ tag_command() {
   esac
 }
 
+validate_target_component() {
+  local label=$1 value=$2
+  [ -n "$value" ] || die "$label cannot be empty"
+  printf '%s\n' "$value" | LC_ALL=C grep -Eq '^[A-Za-z0-9][A-Za-z0-9_-]*$' || \
+    die "$label contains unsupported characters: $value"
+}
+
+parse_target() {
+  local target=$1 site env remainder
+  case "$target" in
+    *.*) ;;
+    *) die 'target must use Pantheon site.environment syntax' ;;
+  esac
+  site=${target%%.*}
+  remainder=${target#*.}
+  case "$remainder" in
+    *.*) die 'target must contain exactly one dot between site and environment' ;;
+  esac
+  env=$remainder
+  validate_target_component site "$site"
+  validate_target_component environment "$env"
+  printf '%s\n%s\n' "$site" "$env"
+}
+
+sanitize_local_name() {
+  local input=$1 normalized hash prefix
+  normalized=$(printf '%s' "$input" | tr '[:upper:]_' '[:lower:]-' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//; s/-*$//; s/--*/-/g')
+  [ -n "$normalized" ] || die 'could not derive a safe local project name'
+
+  if [ "${#normalized}" -gt 63 ]; then
+    hash=$(printf '%s' "$input" | git hash-object --stdin | cut -c1-8)
+    prefix=$(printf '%s' "$normalized" | cut -c1-54 | sed 's/-*$//')
+    normalized="$prefix-$hash"
+  fi
+  printf '%s\n' "$normalized"
+}
+
+terminus_preflight() {
+  require_command terminus
+  if ! terminus auth:whoami >/dev/null 2>&1; then
+    die 'Terminus is not authenticated. See https://docs.pantheon.io/machine-tokens and run terminus auth:login first.'
+  fi
+}
+
+terminus_field() {
+  local command=$1 target=$2 field=$3 value
+  if ! value=$(terminus "$command" "$target" "--field=$field"); then
+    die "Terminus failed: $command $target --field=$field"
+  fi
+  [ -n "$value" ] || die "Terminus returned an empty $field for $target"
+  printf '%s\n' "$value"
+}
+
+tag_in_remote_list() {
+  local wanted=$1 remote_tags=$2 line
+  while IFS= read -r line; do
+    [ "$line" = "$wanted" ] && return 0
+  done <<EOF
+$remote_tags
+EOF
+  return 1
+}
+
+resolve_tag_route() {
+  local site=$1 mappings org remote_tags line mapped_tag mapped_dir
+  local matched_tag='' matched_dir='' matches=0
+  mappings=$(tag_list)
+
+  if [ -z "$mappings" ]; then
+    printf '\n\n'
+    return
+  fi
+
+  org=$(terminus_field site:info "$site" organization)
+  if ! remote_tags=$(terminus tag:list "$site" "$org" --format=list); then
+    die "Terminus failed while reading Pantheon Tags for $site"
+  fi
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    mapped_tag=${line%%=*}
+    mapped_dir=${line#*=}
+    if tag_in_remote_list "$mapped_tag" "$remote_tags"; then
+      matches=$((matches + 1))
+      matched_tag=$mapped_tag
+      matched_dir=$mapped_dir
+    fi
+  done <<EOF
+$mappings
+EOF
+
+  case "$matches" in
+    1) printf '%s\n%s\n' "$matched_tag" "$matched_dir" ;;
+    0) die "site $site has no Pantheon Tag matching a configured local Tag route" ;;
+    *) die "site $site matches more than one configured Pantheon Tag route; refusing to guess" ;;
+  esac
+}
+
+configured_provider() {
+  local override=$1 provider
+  if [ -n "$override" ]; then
+    case "$override" in
+      ddev|lando) printf '%s\n' "$override" ;;
+      *) die '--provider must be ddev or lando' ;;
+    esac
+    return
+  fi
+  provider=$(config_get provider)
+  validate_value provider "$provider"
+  printf '%s\n' "$provider"
+}
+
+detect_provider() {
+  local checkout=$1 has_ddev=false has_lando=false
+  [ -f "$checkout/.ddev/config.yaml" ] && has_ddev=true
+  [ -f "$checkout/.lando.yml" ] && has_lando=true
+
+  case "$has_ddev:$has_lando" in
+    true:false) printf '%s\n' ddev ;;
+    false:true) printf '%s\n' lando ;;
+    true:true) die 'both DDEV and Lando project configuration were found; choose --provider explicitly' ;;
+    false:false) die 'neither DDEV nor Lando project configuration was found; choose/configure a supported provider project first' ;;
+  esac
+}
+
+ensure_provider_project() {
+  local provider=$1 checkout=$2
+  case "$provider" in
+    ddev) [ -f "$checkout/.ddev/config.yaml" ] || die 'DDEV provider selected but .ddev/config.yaml is missing' ;;
+    lando) [ -f "$checkout/.lando.yml" ] || die 'Lando provider selected but .lando.yml is missing' ;;
+    *) die "unsupported provider: $provider" ;;
+  esac
+}
+
+add_local_exclude() {
+  local checkout=$1 path=$2 exclude="$checkout/.git/info/exclude"
+  mkdir -p "${exclude%/*}"
+  touch "$exclude"
+  grep -Fx "$path" "$exclude" >/dev/null 2>&1 || printf '%s\n' "$path" >> "$exclude"
+}
+
+write_lando_override() {
+  local checkout=$1 local_name=$2 framework=$3 file="$checkout/.lando.local.yml"
+  [ ! -e "$file" ] || die 'refusing to overwrite existing .lando.local.yml'
+
+  {
+    printf 'name: %s\n' "$local_name"
+    case "$framework" in
+      drupal|drupal8)
+        printf '\ntooling:\n'
+        printf '  drush:\n'
+        printf '    env:\n'
+        printf '      DRUSH_OPTIONS_URI: "http://%s.lndo.site"\n' "$local_name"
+        ;;
+    esac
+  } > "$file"
+  add_local_exclude "$checkout" '.lando.local.yml'
+}
+
+write_ddev_override() {
+  local checkout=$1 local_name=$2 file="$checkout/.ddev/config.local.yaml"
+  [ ! -e "$file" ] || die 'refusing to overwrite existing .ddev/config.local.yaml'
+  printf 'name: %s\n' "$local_name" > "$file"
+  add_local_exclude "$checkout" '.ddev/config.local.yaml'
+}
+
+provider_url() {
+  local provider=$1 local_name=$2
+  case "$provider" in
+    ddev) printf 'https://%s.ddev.site\n' "$local_name" ;;
+    lando) printf 'http://%s.lndo.site\n' "$local_name" ;;
+    auto) printf '%s\n' '(resolved after clone)' ;;
+    *) die "unsupported provider: $provider" ;;
+  esac
+}
+
+write_checkout_state() {
+  local checkout=$1 site=$2 env=$3 tag=$4 provider=$5 local_name=$6 url=$7 state
+  state="$checkout/.git/pantheon-local-tools/state"
+  mkdir -p "${state%/*}"
+  git config --file "$state" --replace-all pantheon.site "$site"
+  git config --file "$state" --replace-all pantheon.environment "$env"
+  [ -n "$tag" ] && git config --file "$state" --replace-all pantheon.tag "$tag"
+  git config --file "$state" --replace-all local.provider "$provider"
+  git config --file "$state" --replace-all local.name "$local_name"
+  git config --file "$state" --replace-all local.url "$url"
+}
+
+cleanup_multidev_temp() {
+  if [ -n "$MULTIDEV_TEMP" ] && [ -d "$MULTIDEV_TEMP" ]; then
+    rm -rf "$MULTIDEV_TEMP"
+  fi
+}
+
+print_multidev_plan() {
+  local heading=$1 target=$2 tag=$3 provider=$4 env=$5 destination=$6 local_name=$7 url=$8
+  printf '%s\n\n' "$heading"
+  printf 'Pantheon:    %s\n' "$target"
+  if [ -n "$tag" ]; then
+    printf 'Tag:         %s\n' "$tag"
+  else
+    printf 'Tag:         (no configured Tag routing)\n'
+  fi
+  printf 'Provider:    %s\n' "$provider"
+  printf 'Git branch:  %s\n' "$env"
+  printf 'Directory:   %s\n' "$destination"
+  printf 'Local name:  %s\n' "$local_name"
+  printf 'Local URL:   %s\n' "$url"
+}
+
+multidev_command() {
+  local target='' provider_override='' group='' dry_run=false start=false
+  local parsed site env route tag route_dir root base_dir destination local_name
+  local provider git_url parent tmp framework='' url
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --provider)
+        [ "$#" -ge 2 ] || die '--provider requires ddev or lando'
+        provider_override=$2
+        shift 2
+        ;;
+      --group)
+        [ "$#" -ge 2 ] || die '--group requires a name'
+        group=$2
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      --start)
+        start=true
+        shift
+        ;;
+      -h|--help|help)
+        usage
+        return
+        ;;
+      --*) die "unknown multidev option: $1" ;;
+      *)
+        [ -z "$target" ] || die 'multidev accepts exactly one SITE.ENV target'
+        target=$1
+        shift
+        ;;
+    esac
+  done
+
+  [ -n "$target" ] || die 'usage: pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]'
+  [ -z "$group" ] || validate_group "$group"
+  [ "$dry_run" = false ] || [ "$start" = false ] || die '--start cannot be combined with --dry-run'
+
+  require_command git
+  parsed=$(parse_target "$target")
+  site=$(printf '%s\n' "$parsed" | sed -n '1p')
+  env=$(printf '%s\n' "$parsed" | sed -n '2p')
+  local_name=$(sanitize_local_name "$site-$env")
+  provider=$(configured_provider "$provider_override")
+
+  terminus_preflight
+  route=$(resolve_tag_route "$site")
+  tag=$(printf '%s\n' "$route" | sed -n '1p')
+  route_dir=$(printf '%s\n' "$route" | sed -n '2p')
+  git_url=$(terminus_field connection:info "$target" git_url)
+
+  root=$(config_get root)
+  if [ -n "$route_dir" ]; then
+    base_dir="$root/$route_dir/multidev"
+  else
+    base_dir="$root/multidev"
+  fi
+  [ -z "$group" ] || base_dir="$base_dir/$group"
+  destination="$base_dir/$local_name"
+
+  [ ! -e "$destination" ] || die "destination already exists: $destination"
+
+  if [ "$dry_run" = true ]; then
+    url=$(provider_url "$provider" "$local_name")
+    print_multidev_plan 'Pantheon multidev dry-run' "$target" "$tag" "$provider" "$env" "$destination" "$local_name" "$url"
+    return
+  fi
+
+  mkdir -p "$base_dir"
+  parent=${destination%/*}
+  tmp=$(mktemp -d "$parent/.${local_name}.tmp.XXXXXX")
+  MULTIDEV_TEMP=$tmp
+  trap cleanup_multidev_temp EXIT HUP INT TERM
+
+  if ! git clone --branch "$env" --single-branch "$git_url" "$tmp"; then
+    die "Git clone failed for Pantheon environment: $target"
+  fi
+
+  if [ "$provider" = auto ]; then
+    provider=$(detect_provider "$tmp")
+  fi
+  ensure_provider_project "$provider" "$tmp"
+
+  case "$provider" in
+    lando)
+      framework=$(terminus_field site:info "$site" framework)
+      write_lando_override "$tmp" "$local_name" "$framework"
+      ;;
+    ddev)
+      write_ddev_override "$tmp" "$local_name"
+      ;;
+  esac
+
+  url=$(provider_url "$provider" "$local_name")
+  write_checkout_state "$tmp" "$site" "$env" "$tag" "$provider" "$local_name" "$url"
+
+  mv "$tmp" "$destination"
+  MULTIDEV_TEMP=''
+  trap - EXIT HUP INT TERM
+
+  print_multidev_plan 'Created Pantheon multidev checkout' "$target" "$tag" "$provider" "$env" "$destination" "$local_name" "$url"
+
+  if [ "$start" = true ]; then
+    require_command "$provider"
+    printf '\nStarting %s...\n' "$provider"
+    if ! (cd "$destination" && "$provider" start); then
+      die "$provider start failed; checkout retained at $destination"
+    fi
+  fi
+}
+
 main() {
   local command=${1:-}
   case "$command" in
     config)
       shift
       config_command "$@"
+      ;;
+    multidev)
+      shift
+      multidev_command "$@"
       ;;
     -h|--help|help|'') usage ;;
     *) die "unknown command: $command" ;;

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -433,14 +433,16 @@ ensure_provider_project() {
 }
 
 add_local_exclude() {
-  local checkout=$1 path=$2 exclude="$checkout/.git/info/exclude"
+  local checkout=$1 path=$2 exclude
+  exclude="$checkout/.git/info/exclude"
   mkdir -p "${exclude%/*}"
   touch "$exclude"
   grep -Fx "$path" "$exclude" >/dev/null 2>&1 || printf '%s\n' "$path" >> "$exclude"
 }
 
 write_lando_override() {
-  local checkout=$1 local_name=$2 framework=$3 file="$checkout/.lando.local.yml"
+  local checkout=$1 local_name=$2 framework=$3 file
+  file="$checkout/.lando.local.yml"
   [ ! -e "$file" ] || die 'refusing to overwrite existing .lando.local.yml'
 
   {
@@ -458,7 +460,8 @@ write_lando_override() {
 }
 
 write_ddev_override() {
-  local checkout=$1 local_name=$2 file="$checkout/.ddev/config.local.yaml"
+  local checkout=$1 local_name=$2 file
+  file="$checkout/.ddev/config.local.yaml"
   [ ! -e "$file" ] || die 'refusing to overwrite existing .ddev/config.local.yaml'
   printf 'name: %s\n' "$local_name" > "$file"
   add_local_exclude "$checkout" '.ddev/config.local.yaml'

--- a/config.example
+++ b/config.example
@@ -7,14 +7,11 @@
 #   ~/.config/pantheon-local-tools/config
 #
 # All values below are generic examples only. Organization-specific Pantheon
-# Tags, prefixes, and directory names belong in each user's local config.
+# Tags and directory names belong in each user's local config.
 
 [local]
     root = ~/sites/pantheon
     provider = auto
-
-[pantheon]
-    sitePrefix =
 
 [tag "Example Group"]
     directory = example-group

--- a/docs/local-provider-architecture.md
+++ b/docs/local-provider-architecture.md
@@ -2,23 +2,13 @@
 
 Pantheon Local Tools separates Pantheon operations from the local development environment used to run a project.
 
-The canonical CLI is `pantheon-local`. Commands such as `pantheon-local multidev`, `pantheon-local pull`, and `pantheon-local status` expose one consistent user workflow while delegating environment-specific details to a provider adapter.
+The goal is for commands such as `pantheon-local multidev`, `pantheon-local pull`, and `pantheon-local status` to expose one consistent user workflow while delegating environment-specific details to a provider adapter.
 
-## Host environments
-
-The shell tooling targets:
-
-- macOS;
-- Linux; and
-- Windows through WSL/WSL2.
-
-Native PowerShell and Command Prompt are not initial targets. WSL is treated as a Linux execution environment: commands use Linux paths such as `/home/user/...` or `/mnt/c/...`, not `C:\...` paths.
-
-Portable shell code avoids Bash 4-only features so the same core can run under the older Bash shipped by macOS and modern Bash on Linux/WSL.
+The initial release is being validated against Drupal projects. The shared Pantheon/Terminus core should remain framework-neutral where doing so does not weaken validation or safety.
 
 ## Why providers
 
-Drupal.org currently recommends DDEV for Drupal local development, while many existing Pantheon projects use Lando. Pantheon also documents DDEV integration with its platform. The tool should not require a team to standardize on one local container stack before it can use the Pantheon workflow helpers.
+Drupal.org recommends DDEV for Drupal local development, while many existing Pantheon projects use Lando. The tool should not require a team to standardize on one local container stack before it can use the shared Pantheon workflow helpers.
 
 The shared core therefore owns Pantheon concepts. Provider adapters own local-runtime concepts.
 
@@ -27,30 +17,17 @@ The shared core therefore owns Pantheon concepts. Provider adapters own local-ru
 The core is responsible for:
 
 - parsing a Pantheon `site.environment` target;
-- verifying required commands and Terminus authentication before Pantheon operations;
+- checking Terminus authentication before Pantheon operations;
 - querying Terminus for authoritative site and environment information;
 - reading Pantheon Tags and applying user-configured Tag-to-directory mappings;
 - obtaining the authoritative Git connection for an environment;
 - choosing and creating the local destination path;
 - refusing to overwrite an existing checkout;
-- cloning the selected Pantheon environment;
 - selecting a provider without guessing when the result is ambiguous;
-- recording non-secret local state needed by status output;
+- recording non-secret local state needed by later status commands; and
 - presenting consistent errors and status output.
 
-The core must not assume DDEV or Lando naming, URL, start, rebuild, or data-pull behavior.
-
-## Terminus authentication boundary
-
-Pantheon Local Tools does not own or store Pantheon credentials. Users authenticate Terminus using Pantheon's supported workflow before running commands that query Pantheon.
-
-The tool should preflight Terminus and provide an actionable error when authentication is missing. It must never prompt for, persist, echo, or copy a Pantheon machine token into Pantheon Local Tools configuration.
-
-Pantheon's canonical references are:
-
-- https://docs.pantheon.io/terminus/install
-- https://docs.pantheon.io/machine-tokens
-- https://docs.pantheon.io/terminus/commands/auth-login
+The core must not assume DDEV or Lando naming, start, rebuild, or data-pull behavior.
 
 ## Provider responsibilities
 
@@ -58,39 +35,43 @@ A provider adapter is responsible for local behavior such as:
 
 - detecting whether its project configuration is present;
 - creating local-only configuration for an isolated checkout;
-- calculating or discovering the local project name and URL;
-- starting or restarting the local environment when explicitly requested;
-- pulling/importing database and files through the provider's supported workflow;
+- calculating the local project name and URL;
+- starting the local environment when explicitly requested;
+- eventually importing database/files through the provider's supported workflow; and
 - reporting provider-specific status.
 
-The first providers are:
+The first providers are DDEV and Lando.
 
 ### DDEV
 
 DDEV projects use `.ddev/config.yaml` and may use local-only `config.*.yaml` overrides such as `.ddev/config.local.yaml`.
 
-Pantheon documents a DDEV provider integration that supports `ddev pull pantheon`. Where the project is configured for that integration, the DDEV adapter should prefer the documented DDEV workflow rather than reimplementing it.
+The current multidev implementation requires an existing `.ddev/config.yaml`; it does not synthesize the project's base DDEV configuration. It creates only the isolated local name override.
+
+Pantheon documents DDEV provider integration that supports `ddev pull pantheon`. The later `pull` command should prefer supported provider integration when the project is configured for it rather than reimplementing provider behavior unnecessarily.
 
 ### Lando
 
-Lando projects use `.lando.yml`. Checkout-specific settings can be placed in `.lando.local.yml` and kept outside version control.
+Lando projects use `.lando.yml`. Checkout-specific settings can be placed in `.lando.local.yml`, which Lando loads after the shared Landofile.
 
-The Lando adapter should preserve the project's existing recipe and services while applying only the minimum local overrides needed for an isolated checkout.
+The current multidev implementation requires an existing `.lando.yml` and creates only the minimum local override needed for an isolated checkout. For Drupal sites it also corrects `DRUSH_OPTIONS_URI` to the isolated local app URL.
 
 ## Provider selection
 
 Provider selection follows this precedence:
 
 1. explicit command option (`--provider ddev` or `--provider lando`);
-2. user configuration (`local.provider`);
-3. unambiguous provider configuration found in the project after cloning;
+2. user configuration (`pantheon-local config set provider ...`);
+3. unambiguous provider configuration found in the cloned project when the configured value is `auto`;
 4. otherwise fail and require an explicit choice.
 
 `auto` is a detection mode, not permission to guess.
 
-If both DDEV and Lando configurations exist, or neither can be identified reliably, the command must stop unless the user supplied a provider explicitly or configured a default.
+If both DDEV and Lando configurations exist, or neither can be identified reliably, the command stops unless the user supplied or configured a provider.
 
-## Git-style local configuration
+A dry-run cannot inspect a future checkout, so `provider=auto` requires `--provider` for a fully resolved multidev dry-run.
+
+## Local configuration
 
 User configuration lives outside project repositories, by default at:
 
@@ -98,13 +79,7 @@ User configuration lives outside project repositories, by default at:
 ~/.config/pantheon-local-tools/config
 ```
 
-The file uses Git's config format and is read/written through Git itself. Users normally manage it through commands such as:
-
-```bash
-pantheon-local config set root ~/sites/pantheon
-pantheon-local config set provider ddev
-pantheon-local config tag set "Client Sites" clients
-```
+The file uses Git-compatible configuration data and is normally managed through `pantheon-local config` commands instead of manual editing.
 
 The root directory is configurable. The project does not assume `~/lando`, `~/sites/pantheon`, or any organization-specific directory layout.
 
@@ -113,20 +88,19 @@ Pantheon Tag routing is also user-defined. Pantheon Tags are the authoritative s
 ## Safety rules
 
 - Never overwrite an existing checkout.
+- Build a new multidev checkout in a temporary sibling path and finalize it only after provider configuration succeeds.
 - Never commit machine-specific provider overrides automatically.
 - Never embed Pantheon tokens, SSH keys, credentials, or organization-private values.
-- Never store executable shell code as user configuration.
 - Never start, rebuild, delete, or otherwise mutate a local runtime as a hidden side effect.
 - Never perform a Pantheon remote write unless the user explicitly requested an operation that requires it.
-- Fail on ambiguous Pantheon Tag routing or provider selection instead of guessing.
-- Under WSL, use Linux path semantics and reject native Windows path syntax where it would be unsafe or ambiguous.
+- Fail on ambiguous Tag routing or provider selection instead of guessing.
+- Keep organization-specific Pantheon Tags and directory mappings out of the repository.
 
 ## Upstream references
 
 - Drupal local server setup: https://www.drupal.org/docs/develop/local-server-setup
-- Pantheon Terminus install/authentication: https://docs.pantheon.io/terminus/install
-- Pantheon machine tokens: https://docs.pantheon.io/machine-tokens
-- Pantheon `auth:login`: https://docs.pantheon.io/terminus/commands/auth-login
 - Pantheon DDEV guide: https://docs.pantheon.io/guides/local-development/ddev
 - Pantheon local development guide: https://docs.pantheon.io/guides/local-development
+- Pantheon Terminus commands: https://docs.pantheon.io/terminus/commands
 - DDEV configuration overrides: https://ddev.readthedocs.io/en/stable/users/configuration/config/
+- Lando Landofile override files: https://docs.lando.dev/landofile/index.html

--- a/docs/multidev.md
+++ b/docs/multidev.md
@@ -1,0 +1,87 @@
+# Multidev Checkout Workflow
+
+`pantheon-local multidev SITE.ENV` creates a local checkout for an existing Pantheon multidev environment without changing that environment on Pantheon.
+
+## Pantheon contracts
+
+The implementation relies on documented Terminus interfaces:
+
+- `terminus auth:whoami` verifies that Terminus has an authenticated identity.
+- `terminus site:info <site> --field=organization` resolves the site's organization when Pantheon Tag routing is configured.
+- `terminus tag:list <site> <org> --format=list` returns the Pantheon Tags for routing.
+- `terminus site:info <site> --field=framework` supplies framework metadata used only where a provider needs a framework-specific local override.
+- `terminus connection:info <site>.<env> --field=git_url` supplies the Git endpoint used for cloning.
+
+The command never constructs a Pantheon Git URL from UUID assumptions.
+
+## Tag routing
+
+Pantheon Tags are the remote source labels. Local directories are user-defined destinations.
+
+When the user has no Tag mappings, multidev checkouts live directly below:
+
+```text
+<root>/multidev/
+```
+
+When mappings exist, exactly one configured Tag must match the site's Pantheon Tags. A zero-match or multi-match result stops the command so that it never guesses where a checkout belongs.
+
+## Local names
+
+The local name is derived from `<site>-<env>`, normalized to lowercase DNS-safe characters, and limited to 63 characters. Pantheon site and environment names are preserved unchanged for all remote operations; only the derived local name is normalized.
+
+## Transactional local creation
+
+The command refuses to overwrite an existing final destination.
+
+For a real clone, it creates a temporary sibling checkout, validates/configures the selected provider there, records local state, and only then moves the completed checkout into the final destination. If cloning or provider configuration fails, the temporary checkout is removed rather than leaving a partial final destination.
+
+An explicitly requested provider start happens only after the final checkout exists. If a provider start fails, the completed checkout is retained for troubleshooting.
+
+## Provider behavior
+
+### Lando
+
+The project must contain `.lando.yml`.
+
+Pantheon Local Tools writes `.lando.local.yml` with an isolated local app name. For Drupal framework values, it also overrides `DRUSH_OPTIONS_URI` so a committed project-level URI cannot point Drush at a different local Lando app name.
+
+The generated override is added to `.git/info/exclude`. The shared `.gitignore` is not modified.
+
+`--start` runs `lando start`. The tool does not automatically run `lando rebuild`.
+
+### DDEV
+
+The project must contain `.ddev/config.yaml`.
+
+Pantheon Local Tools writes `.ddev/config.local.yaml` with the isolated local project name. DDEV already treats local config overrides as local-only, and the tool additionally records the generated path in `.git/info/exclude` without modifying the project `.gitignore`.
+
+`--start` runs `ddev start`.
+
+## Dry-run
+
+`--dry-run` performs the read-only Terminus lookups and prints the resolved plan without creating directories, cloning Git, or writing provider configuration.
+
+If provider selection is `auto`, dry-run cannot inspect the future checkout. Configure a provider or pass `--provider ddev|lando` for a fully resolved dry-run.
+
+## Non-goals
+
+The multidev command does not:
+
+- create or delete Pantheon multidev environments;
+- change Pantheon connection modes;
+- push code to Pantheon;
+- pull databases or files;
+- store Pantheon machine tokens;
+- overwrite existing local checkouts; or
+- create a project's base DDEV/Lando configuration when none exists.
+
+## Upstream references
+
+- Pantheon `connection:info`: https://docs.pantheon.io/terminus/commands/connection-info
+- Pantheon `site:info`: https://docs.pantheon.io/terminus/commands/site-info
+- Pantheon `tag:list`: https://docs.pantheon.io/terminus/commands/tag-list
+- Pantheon Terminus install: https://docs.pantheon.io/terminus/install
+- Pantheon machine tokens: https://docs.pantheon.io/machine-tokens
+- DDEV configuration overrides: https://ddev.readthedocs.io/en/stable/users/configuration/config/
+- Lando override files: https://docs.lando.dev/landofile/index.html

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -42,9 +42,6 @@ bash "$CLI" config set provider lando
 assert_eq "$(bash "$CLI" config get provider)" 'lando'
 if bash "$CLI" config set provider nope >/dev/null 2>&1; then fail 'invalid provider was accepted'; fi
 
-bash "$CLI" config set site-prefix example
-assert_eq "$(bash "$CLI" config get site-prefix)" 'example'
-
 bash "$CLI" config tag set 'Client Sites.v2' 'clients/main'
 assert_eq "$(bash "$CLI" config tag get 'Client Sites.v2')" 'clients/main'
 assert_contains "$(bash "$CLI" config tag list)" 'Client Sites.v2=clients/main'
@@ -56,8 +53,8 @@ if bash "$CLI" config tag set Unsafe 'foo\\bar' >/dev/null 2>&1; then fail 'back
 output=$(bash "$CLI" config list)
 assert_contains "$output" "root=$HOME/Pantheon Sites"
 assert_contains "$output" 'provider=lando'
-assert_contains "$output" 'site-prefix=example'
 assert_contains "$output" 'tag.Client Sites.v2=clients/main'
+if printf '%s\n' "$output" | grep -q 'site-prefix'; then fail 'removed site-prefix setting is still exposed'; fi
 
 bash "$CLI" config unset provider
 assert_eq "$(bash "$CLI" config get provider)" 'auto'

--- a/tests/test-multidev.sh
+++ b/tests/test-multidev.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+CLI=${CLI:-"$REPO_ROOT/bin/pantheon-local"}
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+export HOME="$TMP_ROOT/home"
+export PANTHEON_LOCAL_CONFIG="$TMP_ROOT/config/pantheon-local-tools/config"
+MOCK_BIN="$TMP_ROOT/bin"
+LOCAL_ROOT="$TMP_ROOT/sites"
+SOURCE_LANDO="$TMP_ROOT/source-lando"
+SOURCE_DDEV="$TMP_ROOT/source-ddev"
+mkdir -p "$HOME" "$MOCK_BIN"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
+assert_file_contains() { grep -F "$2" "$1" >/dev/null 2>&1 || fail "expected $1 to contain [$2]"; }
+
+cat > "$MOCK_BIN/terminus" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  auth:whoami)
+    printf '%s\n' 'developer@example.com'
+    ;;
+  site:info)
+    case "${3:-}" in
+      --field=organization) printf '%s\n' "${MOCK_ORG:-Example Org}" ;;
+      --field=framework) printf '%s\n' "${MOCK_FRAMEWORK:-drupal8}" ;;
+      *) printf 'unexpected site:info arguments\n' >&2; exit 2 ;;
+    esac
+    ;;
+  tag:list)
+    printf '%s\n' "${MOCK_TAGS:-Example Group}"
+    ;;
+  connection:info)
+    [ "${3:-}" = '--field=git_url' ] || { printf 'unexpected connection:info arguments\n' >&2; exit 2; }
+    printf '%s\n' "${MOCK_GIT_URL:?MOCK_GIT_URL is required}"
+    ;;
+  *)
+    printf 'unexpected terminus command: %s\n' "${1:-}" >&2
+    exit 2
+    ;;
+esac
+MOCK
+chmod +x "$MOCK_BIN/terminus"
+
+cat > "$MOCK_BIN/lando" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = start ] || exit 2
+printf '%s\n' "$PWD" >> "${MOCK_START_LOG:?MOCK_START_LOG is required}"
+MOCK
+chmod +x "$MOCK_BIN/lando"
+
+cat > "$MOCK_BIN/ddev" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = start ] || exit 2
+printf '%s\n' "$PWD" >> "${MOCK_START_LOG:?MOCK_START_LOG is required}"
+MOCK
+chmod +x "$MOCK_BIN/ddev"
+
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_START_LOG="$TMP_ROOT/start.log"
+
+create_repo() {
+  local path=$1 provider=$2
+  mkdir -p "$path"
+  git -C "$path" init -q
+  git -C "$path" config user.name 'Test User'
+  git -C "$path" config user.email 'test@example.com'
+  case "$provider" in
+    lando)
+      printf 'name: example-site\nrecipe: pantheon\n' > "$path/.lando.yml"
+      ;;
+    ddev)
+      mkdir -p "$path/.ddev"
+      printf 'name: example-ddev\ntype: drupal11\n' > "$path/.ddev/config.yaml"
+      ;;
+    *) fail "unknown fixture provider: $provider" ;;
+  esac
+  git -C "$path" add .
+  git -C "$path" commit -qm 'Create provider fixture'
+  git -C "$path" branch feature1
+  git -C "$path" branch feature2
+  git -C "$path" branch feature3
+}
+
+create_repo "$SOURCE_LANDO" lando
+create_repo "$SOURCE_DDEV" ddev
+
+export MOCK_GIT_URL="$SOURCE_LANDO"
+export MOCK_TAGS='Example Group'
+export MOCK_ORG='Example Org'
+export MOCK_FRAMEWORK='drupal8'
+
+bash "$CLI" config set root "$LOCAL_ROOT"
+bash "$CLI" config set provider lando
+bash "$CLI" config tag set 'Example Group' clients
+
+# Dry-run resolves Pantheon metadata and routing but makes no checkout directories.
+dry_output=$(bash "$CLI" multidev example-site.feature1 --group migration --dry-run)
+assert_contains "$dry_output" 'Pantheon multidev dry-run'
+assert_contains "$dry_output" 'Tag:         Example Group'
+assert_contains "$dry_output" 'Provider:    lando'
+assert_contains "$dry_output" "$LOCAL_ROOT/clients/multidev/migration/example-site-feature1"
+[ ! -e "$LOCAL_ROOT/clients/multidev/migration/example-site-feature1" ] || fail 'dry-run created a checkout'
+
+# A real Lando checkout is cloned transactionally and receives only local overrides.
+bash "$CLI" multidev example-site.feature1 --group migration >/dev/null
+LANDO_DEST="$LOCAL_ROOT/clients/multidev/migration/example-site-feature1"
+[ -d "$LANDO_DEST/.git" ] || fail 'Lando checkout was not cloned'
+assert_eq "$(git -C "$LANDO_DEST" rev-parse --abbrev-ref HEAD)" 'feature1'
+assert_file_contains "$LANDO_DEST/.lando.local.yml" 'name: example-site-feature1'
+assert_file_contains "$LANDO_DEST/.lando.local.yml" 'DRUSH_OPTIONS_URI: "http://example-site-feature1.lndo.site"'
+assert_file_contains "$LANDO_DEST/.git/info/exclude" '.lando.local.yml'
+assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get pantheon.site)" 'example-site'
+assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get pantheon.environment)" 'feature1'
+assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get pantheon.tag)" 'Example Group'
+assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get local.provider)" 'lando'
+
+if bash "$CLI" multidev example-site.feature1 --group migration >/dev/null 2>&1; then
+  fail 'existing destination was overwritten or reused'
+fi
+
+# Configured Tag routing must resolve to exactly one Pantheon Tag.
+bash "$CLI" config tag set 'Another Group' another
+export MOCK_TAGS=$(printf 'Example Group\nAnother Group')
+if bash "$CLI" multidev example-site.feature2 --dry-run >/dev/null 2>&1; then
+  fail 'ambiguous Pantheon Tag routing was accepted'
+fi
+export MOCK_TAGS='Unmapped Group'
+if bash "$CLI" multidev example-site.feature2 --dry-run >/dev/null 2>&1; then
+  fail 'unmatched Pantheon Tag routing was accepted'
+fi
+
+# With no Tag mappings, checkouts route directly under <root>/multidev.
+bash "$CLI" config tag unset 'Example Group'
+bash "$CLI" config tag unset 'Another Group'
+export MOCK_TAGS='Anything'
+no_tag_output=$(bash "$CLI" multidev example-site.feature2 --dry-run)
+assert_contains "$no_tag_output" 'Tag:         (no configured Tag routing)'
+assert_contains "$no_tag_output" "$LOCAL_ROOT/multidev/example-site-feature2"
+
+# auto detects an unambiguous provider from the cloned project.
+bash "$CLI" config set provider auto
+bash "$CLI" multidev example-site.feature2 >/dev/null
+AUTO_DEST="$LOCAL_ROOT/multidev/example-site-feature2"
+assert_file_contains "$AUTO_DEST/.lando.local.yml" 'name: example-site-feature2'
+assert_eq "$(git config --file "$AUTO_DEST/.git/pantheon-local-tools/state" --get local.provider)" 'lando'
+
+# DDEV is a first-class provider and writes its local override without touching shared config.
+export MOCK_GIT_URL="$SOURCE_DDEV"
+bash "$CLI" config set provider ddev
+bash "$CLI" multidev example-ddev.feature1 >/dev/null
+DDEV_DEST="$LOCAL_ROOT/multidev/example-ddev-feature1"
+[ -f "$DDEV_DEST/.ddev/config.yaml" ] || fail 'DDEV base configuration is missing after clone'
+assert_file_contains "$DDEV_DEST/.ddev/config.local.yaml" 'name: example-ddev-feature1'
+assert_file_contains "$DDEV_DEST/.git/info/exclude" '.ddev/config.local.yaml'
+assert_eq "$(git config --file "$DDEV_DEST/.git/pantheon-local-tools/state" --get local.provider)" 'ddev'
+assert_eq "$(git config --file "$DDEV_DEST/.git/pantheon-local-tools/state" --get local.url)" 'https://example-ddev-feature1.ddev.site'
+
+# Runtime start is opt-in and happens only after the completed checkout is in its final path.
+export MOCK_GIT_URL="$SOURCE_LANDO"
+bash "$CLI" config set provider lando
+bash "$CLI" multidev example-site.feature3 --start >/dev/null
+START_DEST="$LOCAL_ROOT/multidev/example-site-feature3"
+assert_file_contains "$MOCK_START_LOG" "$START_DEST"
+
+# Failed clones must not leave the final checkout path behind.
+export MOCK_GIT_URL="$TMP_ROOT/does-not-exist"
+if bash "$CLI" multidev failed-site.feature1 >/dev/null 2>&1; then
+  fail 'failed Git clone unexpectedly succeeded'
+fi
+[ ! -e "$LOCAL_ROOT/multidev/failed-site-feature1" ] || fail 'failed clone left a final destination behind'
+
+printf 'multidev tests passed\n'

--- a/tests/test-multidev.sh
+++ b/tests/test-multidev.sh
@@ -129,7 +129,8 @@ fi
 
 # Configured Tag routing must resolve to exactly one Pantheon Tag.
 bash "$CLI" config tag set 'Another Group' another
-export MOCK_TAGS=$(printf 'Example Group\nAnother Group')
+MOCK_TAGS=$(printf 'Example Group\nAnother Group')
+export MOCK_TAGS
 if bash "$CLI" multidev example-site.feature2 --dry-run >/dev/null 2>&1; then
   fail 'ambiguous Pantheon Tag routing was accepted'
 fi


### PR DESCRIPTION
## Summary

Implement the first Pantheon workflow command: `pantheon-local multidev SITE.ENV`.

- verify Terminus authentication before Pantheon reads
- resolve Pantheon Tag-to-directory routing from user config
- obtain the authoritative Pantheon Git URL through `connection:info`
- clone the requested existing multidev branch transactionally into a temporary sibling path
- refuse to overwrite existing destinations
- support `--dry-run`, `--group`, explicit `--provider ddev|lando`, and opt-in `--start`
- auto-detect DDEV vs Lando only when project configuration is unambiguous
- generate local-only DDEV/Lando overrides and exclude them through `.git/info/exclude`
- correct Drupal Lando `DRUSH_OPTIONS_URI` for isolated checkout names
- record non-secret checkout state under `.git/pantheon-local-tools/state`
- remove the unused `site-prefix` setting before it becomes public API
- add mock Terminus/Git/provider integration tests
- document the multidev safety contract and provider behavior

## Safety

This command only clones an existing Pantheon environment. It does not create/delete multidevs, change connection mode, push code, pull data, or store Pantheon machine tokens. `--start` is explicit and never implies `lando rebuild`.

## Portability

CI exercises syntax, ShellCheck, config behavior, and multidev integration behavior on Ubuntu and macOS. The shell remains Bash 3.2-compatible and uses Linux path semantics under WSL.

## Scope

The initial release is validated against Drupal projects. The shared Pantheon/Terminus core remains framework-neutral where that does not weaken validation or safety. WordPress-specific behavior is intentionally deferred.