### PR TITLE
Add selective database and files pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ pantheon-local multidev SITE.ENV --provider lando --group migration
 pantheon-local multidev SITE.ENV --provider ddev --start
 
 pantheon-local pull live
-pantheon-local pull test
+pantheon-local pull test --database-only
+pantheon-local pull live --files-only
 pantheon-local pull feature-a --provider lando
 
 pantheon-local status
@@ -104,27 +105,30 @@ See [`docs/multidev.md`](docs/multidev.md) for the full safety and provider beha
 
 ## Data pulls
 
-`pantheon-local pull ENV` refreshes the local database and files from one explicitly named Pantheon environment while preserving the checkout's Git code.
+`pantheon-local pull ENV` refreshes local Pantheon data from one explicitly named environment while preserving the checkout's Git code.
+
+By default both database and files are refreshed. Component-specific workflows are explicit:
+
+```bash
+pantheon-local pull live --database-only
+pantheon-local pull live --files-only
+```
+
+This is useful for Drupal workflows such as refreshing only the database before `drush updb` and `drush cex`, where synchronizing files would add time without helping the change being developed.
 
 The command uses the provider already associated with the checkout. If no provider has been recorded, it detects an unambiguous `.lando.yml` or `.ddev/config.yaml`; ambiguous checkouts require `--provider ddev|lando`.
 
-For Lando, the adapter delegates to the Pantheon recipe with explicit data sources and no code source:
+For Lando, the adapter delegates to the Pantheon recipe with explicit sources and always disables code pulls. For example, database-only becomes:
 
 ```text
-lando pull --code=none --database=ENV --files=ENV
+lando pull --code=none --database=ENV --files=none
 ```
 
-For DDEV, the adapter delegates to DDEV's Pantheon provider with a one-time environment override rather than rewriting project configuration:
-
-```text
-ddev pull pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=ENV" -y
-```
-
-When a Pantheon site name is already recorded in local state, DDEV receives both `DDEV_PANTHEON_SITE` and `DDEV_PANTHEON_ENVIRONMENT` for an explicit binding.
+For DDEV, the adapter delegates to DDEV's Pantheon provider with a one-time environment override and maps component selection to DDEV's `--skip-files` / `--skip-db` flags rather than rewriting project configuration.
 
 Pantheon Local Tools does not collect provider machine tokens. Lando/DDEV own their supported Pantheon authentication workflows.
 
-Before and after the provider pull, the tool verifies that Git `HEAD` and all tracked content are unchanged. Only after provider success and that verification does it record `data.source=ENV` for `pantheon-local status`.
+Before and after the provider pull, the tool verifies that Git `HEAD` and all tracked content are unchanged. Only after provider success and that verification does it update component-specific provenance for `pantheon-local status`.
 
 See [`docs/pull.md`](docs/pull.md) for the complete pull safety contract and provider details.
 
@@ -132,7 +136,7 @@ See [`docs/pull.md`](docs/pull.md) for the complete pull safety contract and pro
 
 `pantheon-local status` is a local, read-only inspection command. It can be run from the checkout root or any subdirectory and does not contact Pantheon or start a provider.
 
-For checkouts created by Pantheon Local Tools it reports recorded Pantheon metadata together with current Git state:
+For checkouts created by Pantheon Local Tools it reports recorded Pantheon metadata together with current Git state and independent database/files provenance:
 
 ```text
 Pantheon Local Tools status
@@ -148,12 +152,13 @@ Local URL:       http://example-site-feature-a.lndo.site
 Git branch:      feature-a
 Git tracking:    origin/feature-a
 Git state:       clean
-Data source:     live
+Database source: test
+Files source:    live
 ```
 
 Existing Git checkouts are also supported. When no Pantheon Local Tools state exists, status detects an unambiguous DDEV/Lando project configuration and shows unavailable Pantheon-specific metadata as `(not recorded)` rather than guessing.
 
-`Data source` is written only after a successful `pantheon-local pull`; it is never inferred from the Git branch.
+Database/files sources are written only after successful `pantheon-local pull` operations; they are never inferred from the Git branch.
 
 See [`docs/status.md`](docs/status.md) for the complete status contract.
 

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -8,7 +8,7 @@ usage() {
 Usage:
   pantheon-local config ...
   pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]
-  pantheon-local pull ENV [--provider ddev|lando]
+  pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]
   pantheon-local status
 
 Run `pantheon-local config help` for configuration commands.

--- a/docs/local-provider-architecture.md
+++ b/docs/local-provider-architecture.md
@@ -24,7 +24,7 @@ The core is responsible for:
 - choosing and creating the local destination path;
 - refusing to overwrite an existing checkout;
 - selecting a provider without guessing when the result is ambiguous;
-- recording non-secret local state and data provenance; and
+- recording non-secret local state and component-specific data provenance; and
 - presenting consistent errors and status output.
 
 The shared layer must not reimplement DDEV or Lando database/files synchronization when the provider already supplies a supported Pantheon workflow.
@@ -50,7 +50,13 @@ The multidev workflow requires an existing `.ddev/config.yaml`; it does not synt
 
 For data pulls, DDEV's Pantheon provider is the implementation boundary. `pantheon-local pull ENV` delegates to `ddev pull pantheon` and supplies the requested environment as a one-time `DDEV_PANTHEON_ENVIRONMENT` override. When Pantheon Local Tools has a recorded site name, it also supplies `DDEV_PANTHEON_SITE` for an explicit site/environment binding. The project configuration is not rewritten.
 
-DDEV's provider integration pulls database and files, not Git code.
+Component selectors map directly to DDEV's supported skip flags:
+
+- default: database + files;
+- `--database-only`: add `--skip-files`;
+- `--files-only`: add `--skip-db`.
+
+DDEV's provider integration pulls data, not Git code.
 
 ### Lando
 
@@ -58,13 +64,27 @@ Lando projects use `.lando.yml`. Checkout-specific settings can be placed in `.l
 
 The multidev workflow requires an existing `.lando.yml` and creates only the minimum local override needed for an isolated checkout. For Drupal sites it also corrects `DRUSH_OPTIONS_URI` to the isolated local app URL.
 
-For data pulls, `pantheon-local pull ENV` delegates to Lando's Pantheon recipe with explicit sources:
+For data pulls, Pantheon Local Tools always passes explicit sources and disables code pulls.
+
+Default database + files:
 
 ```text
 lando pull --code=none --database=ENV --files=ENV
 ```
 
-The explicit `--code=none` avoids Lando's default behavior of deriving a code source from the current Git branch.
+Database only:
+
+```text
+lando pull --code=none --database=ENV --files=none
+```
+
+Files only:
+
+```text
+lando pull --code=none --database=none --files=ENV
+```
+
+The explicit source values avoid Lando's default behavior of deriving unspecified sources from the current Git branch.
 
 ## Provider selection
 
@@ -96,7 +116,16 @@ Non-secret state lives inside the checkout's Git metadata:
 .git/pantheon-local-tools/state
 ```
 
-Multidev records site/environment/Tag/provider/local identity. A successful `pull` records `data.source=ENV` only after the provider returns success and the tool verifies that Git `HEAD` and tracked content are unchanged.
+Multidev records site/environment/Tag/provider/local identity. Successful pulls record database and files provenance independently:
+
+```text
+data.database-source=ENV
+data.files-source=ENV
+```
+
+A full pull updates both. A component-only pull updates only the component that actually changed. Provenance is written only after the provider returns success and the tool verifies that Git `HEAD` and tracked content are unchanged.
+
+Older state containing `data.source=ENV` is treated as both component sources and migrated losslessly on the next successful component-aware pull.
 
 This state is local metadata, not application configuration, and is never committed.
 
@@ -123,8 +152,9 @@ Pantheon Tag routing is also user-defined. Pantheon Tags are the authoritative s
 - Never start, rebuild, delete, or otherwise mutate a local runtime as an unrelated hidden side effect.
 - Never perform a Pantheon remote write unless the user explicitly requested an operation that requires it.
 - Pull database/files through documented provider interfaces rather than reimplementing synchronization.
-- Pass explicit pull environments instead of inferring data provenance from the Git branch.
+- Pass explicit pull environments and component choices instead of inferring data provenance from the Git branch.
 - Verify that data pulls did not change Git `HEAD` or tracked content before recording provenance.
+- Record database/files provenance separately so a partial pull cannot misrepresent the untouched component.
 - Fail on ambiguous Tag routing or provider selection instead of guessing.
 - Keep organization-specific Pantheon Tags and directory mappings out of the repository.
 

--- a/docs/pull.md
+++ b/docs/pull.md
@@ -1,8 +1,8 @@
 # Data Pull Workflow
 
-`pantheon-local pull ENV` refreshes the local database and files from one Pantheon environment while preserving the currently checked-out Git code.
+`pantheon-local pull ENV` refreshes Pantheon data in an existing local checkout while preserving the currently checked-out Git code.
 
-Examples:
+By default the command pulls both database and files:
 
 ```bash
 pantheon-local pull dev
@@ -11,7 +11,16 @@ pantheon-local pull live
 pantheon-local pull feature-a
 ```
 
-Pantheon environment names are passed explicitly. The tool never infers database/files provenance from the current Git branch.
+When only one data component is needed, use an explicit selector:
+
+```bash
+pantheon-local pull live --database-only
+pantheon-local pull live --files-only
+```
+
+`--database-only` and `--files-only` are mutually exclusive. Pantheon environment names are always passed explicitly; the tool never infers data provenance from the current Git branch.
+
+A common Drupal module-update workflow is database-only: refresh the database from the desired Pantheon environment, run database updates locally, then export the resulting configuration without spending time synchronizing files that are irrelevant to the change.
 
 ## Provider selection
 
@@ -26,13 +35,27 @@ The user's global default provider is not used to override an existing checkout'
 
 ## Lando
 
-For a Lando Pantheon project, the command delegates to:
+Pantheon Local Tools always disables code pulls and passes every data source explicitly.
+
+Both database and files:
 
 ```text
 lando pull --code=none --database=ENV --files=ENV
 ```
 
-Lando normally derives unspecified pull sources from the current Git branch. Pantheon Local Tools supplies all three source options explicitly and sets `--code=none`, so only database/files are requested.
+Database only:
+
+```text
+lando pull --code=none --database=ENV --files=none
+```
+
+Files only:
+
+```text
+lando pull --code=none --database=none --files=ENV
+```
+
+Lando normally derives unspecified pull sources from the current Git branch. Pantheon Local Tools avoids that ambiguity by specifying the relevant sources explicitly and always setting `--code=none`.
 
 Lando owns its Pantheon authentication interaction. If the Lando Pantheon plugin needs a machine token, it may prompt according to Lando's supported workflow. Pantheon Local Tools does not accept or store the token.
 
@@ -51,13 +74,25 @@ The command delegates to DDEV's Pantheon provider and sets the requested environ
 ddev pull pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=ENV" -y
 ```
 
+Database-only pulls add:
+
+```text
+--skip-files
+```
+
+Files-only pulls add:
+
+```text
+--skip-db
+```
+
 When Pantheon Local Tools already has the Pantheon site recorded in local checkout state, it supplies both values:
 
 ```text
 DDEV_PANTHEON_SITE=SITE,DDEV_PANTHEON_ENVIRONMENT=ENV
 ```
 
-This does not rewrite `.ddev/config.yaml` or the provider recipe. DDEV's Pantheon provider handles database/files synchronization and does not pull Git code.
+This does not rewrite `.ddev/config.yaml` or the provider recipe. DDEV's Pantheon provider handles synchronization and does not pull Git code.
 
 DDEV owns its machine-token configuration. Follow DDEV/Pantheon guidance for `TERMINUS_MACHINE_TOKEN`; Pantheon Local Tools does not collect or persist it.
 
@@ -68,7 +103,7 @@ Before delegating to the provider, Pantheon Local Tools records:
 - the current Git `HEAD`; and
 - a fingerprint of all tracked changes relative to `HEAD`.
 
-After the provider returns successfully, both are checked again. If the provider changed `HEAD` or tracked content, the command exits with an error and does not record a successful data source.
+After the provider returns successfully, both are checked again. If the provider changed `HEAD` or tracked content, the command exits with an error and does not record successful provenance.
 
 This check intentionally ignores untracked/ignored files because a legitimate files pull writes CMS uploads into paths that are normally outside tracked source code.
 
@@ -76,10 +111,11 @@ The tool does not attempt an automatic rollback if a provider or project hook ch
 
 ## Data provenance
 
-After a successful provider pull and successful Git safety verification, the command records:
+Database and files provenance are recorded independently:
 
 ```text
-data.source=ENV
+data.database-source=ENV
+data.files-source=ENV
 ```
 
 inside:
@@ -88,9 +124,19 @@ inside:
 .git/pantheon-local-tools/state
 ```
 
-`pantheon-local status` then displays the recorded source. Provenance is recorded only after success; failed provider pulls and Git-safety failures do not update it.
+A full pull updates both values. `--database-only` updates only `data.database-source`; `--files-only` updates only `data.files-source`.
 
-For an ordinary checkout that was not created by `pantheon-local multidev`, the first successful pull may create this local state file and record the detected provider plus data source.
+Older checkouts may contain the pre-component key:
+
+```text
+data.source=ENV
+```
+
+`pantheon-local status` interprets that legacy value as the source for both database and files. On the first successful component-aware pull, Pantheon Local Tools migrates it into the two component keys before updating the requested component, preserving the provenance of the component that was not refreshed.
+
+Provenance is recorded only after provider success and Git-safety verification. Failed provider pulls and Git-safety failures do not update it.
+
+For an ordinary checkout that was not created by `pantheon-local multidev`, the first successful pull may create this local state file and record the detected provider plus component provenance.
 
 ## Non-goals
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -26,7 +26,8 @@ Local URL:       http://example-site-feature-a.lndo.site
 Git branch:      feature-a
 Git tracking:    origin/feature-a
 Git state:       clean
-Data source:     live
+Database source: test
+Files source:    live
 ```
 
 ## Managed and existing checkouts
@@ -57,13 +58,36 @@ Status only checks whether the expected provider project configuration is presen
 
 It does not run `ddev`, `lando`, Docker, or Terminus. Runtime health and provider-discovered URLs can be added later without changing the local/offline status contract.
 
-## Data source
+## Data provenance
 
-After a successful `pantheon-local pull ENV`, status displays the environment recorded as `data.source` in local Git metadata.
+Database and files sources are reported independently because local development workflows often refresh one without the other.
 
-If no successful database/files source has been recorded, status displays `(not recorded)`. It never infers data provenance from the current Git branch.
+A successful full pull:
 
-Provider failures or post-pull Git-safety failures do not update the recorded data source.
+```bash
+pantheon-local pull live
+```
+
+records `live` for both database and files.
+
+A later database-only pull:
+
+```bash
+pantheon-local pull test --database-only
+```
+
+updates only the database source, so status can correctly report:
+
+```text
+Database source: test
+Files source:    live
+```
+
+If a component has never been successfully pulled, status displays `(not recorded)`. It never infers data provenance from the current Git branch.
+
+Older checkout state may contain a single legacy `data.source` value from releases before component-specific provenance. Status interprets that value as both database and files without modifying the state file. The next successful component-aware pull migrates that legacy value losslessly.
+
+Provider failures or post-pull Git-safety failures do not update component provenance.
 
 ## Safety
 

--- a/libexec/pantheon-local-pull
+++ b/libexec/pantheon-local-pull
@@ -6,10 +6,11 @@ PROGRAM_NAME="pantheon-local"
 usage() {
   cat <<'USAGE'
 Usage:
-  pantheon-local pull ENV [--provider ddev|lando]
+  pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]
 
-Refresh the local database and files from one Pantheon environment without
-changing checked-out Git code.
+Refresh local Pantheon data without changing checked-out Git code.
+By default both database and files are pulled. Use --database-only or
+--files-only when only one data component should be refreshed.
 USAGE
 }
 
@@ -106,16 +107,25 @@ tracked_fingerprint() {
 }
 
 run_lando_pull() {
-  local root=$1 env=$2
+  local root=$1 env=$2 components=$3
   require_command lando
-  (
-    cd "$root"
-    lando pull --code=none --database="$env" --files="$env"
-  )
+
+  case "$components" in
+    both)
+      (cd "$root" && lando pull --code=none --database="$env" --files="$env")
+      ;;
+    database)
+      (cd "$root" && lando pull --code=none --database="$env" --files=none)
+      ;;
+    files)
+      (cd "$root" && lando pull --code=none --database=none --files="$env")
+      ;;
+    *) die "unsupported pull component selection: $components" ;;
+  esac
 }
 
 run_ddev_pull() {
-  local root=$1 env=$2 site=$3 environment_arg
+  local root=$1 env=$2 site=$3 components=$4 environment_arg
   require_command ddev
   [ -f "$root/.ddev/providers/pantheon.yaml" ] || \
     die 'DDEV Pantheon provider is missing: .ddev/providers/pantheon.yaml'
@@ -126,21 +136,67 @@ run_ddev_pull() {
     environment_arg="DDEV_PANTHEON_ENVIRONMENT=$env"
   fi
 
-  (
-    cd "$root"
-    ddev pull pantheon --environment="$environment_arg" -y
-  )
+  case "$components" in
+    both)
+      (cd "$root" && ddev pull pantheon --environment="$environment_arg" -y)
+      ;;
+    database)
+      (cd "$root" && ddev pull pantheon --environment="$environment_arg" --skip-files -y)
+      ;;
+    files)
+      (cd "$root" && ddev pull pantheon --environment="$environment_arg" --skip-db -y)
+      ;;
+    *) die "unsupported pull component selection: $components" ;;
+  esac
+}
+
+migrate_legacy_data_source() {
+  local state=$1 legacy database_source files_source
+  legacy=$(state_get "$state" data.source || true)
+  [ -n "$legacy" ] || return 0
+
+  database_source=$(state_get "$state" data.database-source || true)
+  files_source=$(state_get "$state" data.files-source || true)
+
+  [ -n "$database_source" ] || \
+    git config --file "$state" --replace-all data.database-source "$legacy"
+  [ -n "$files_source" ] || \
+    git config --file "$state" --replace-all data.files-source "$legacy"
+  git config --file "$state" --unset-all data.source >/dev/null 2>&1 || true
 }
 
 record_pull_state() {
-  local state=$1 provider=$2 env=$3
+  local state=$1 provider=$2 env=$3 components=$4
   mkdir -p "${state%/*}"
   git config --file "$state" --replace-all local.provider "$provider"
-  git config --file "$state" --replace-all data.source "$env"
+  migrate_legacy_data_source "$state"
+
+  case "$components" in
+    both)
+      git config --file "$state" --replace-all data.database-source "$env"
+      git config --file "$state" --replace-all data.files-source "$env"
+      ;;
+    database)
+      git config --file "$state" --replace-all data.database-source "$env"
+      ;;
+    files)
+      git config --file "$state" --replace-all data.files-source "$env"
+      ;;
+    *) die "unsupported pull component selection: $components" ;;
+  esac
+}
+
+print_components() {
+  case "$1" in
+    both) printf '%s\n' 'database, files' ;;
+    database) printf '%s\n' 'database only' ;;
+    files) printf '%s\n' 'files only' ;;
+    *) die "unsupported pull component selection: $1" ;;
+  esac
 }
 
 pull_command() {
-  local env='' provider_override='' root git_dir state provider site
+  local env='' provider_override='' components=both root git_dir state provider site
   local head_before head_after diff_before diff_after
 
   while [ "$#" -gt 0 ]; do
@@ -149,6 +205,16 @@ pull_command() {
         [ "$#" -ge 2 ] || die '--provider requires ddev or lando'
         provider_override=$2
         shift 2
+        ;;
+      --database-only)
+        [ "$components" = both ] || die '--database-only and --files-only cannot be combined or repeated'
+        components=database
+        shift
+        ;;
+      --files-only)
+        [ "$components" = both ] || die '--database-only and --files-only cannot be combined or repeated'
+        components=files
+        shift
         ;;
       -h|--help|help)
         usage
@@ -163,7 +229,7 @@ pull_command() {
     esac
   done
 
-  [ -n "$env" ] || die 'usage: pantheon-local pull ENV [--provider ddev|lando]'
+  [ -n "$env" ] || die 'usage: pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]'
   validate_environment "$env"
   require_command git
 
@@ -178,12 +244,13 @@ pull_command() {
 
   printf 'Pulling Pantheon data\n\n'
   printf 'Environment: %s\n' "$env"
+  printf 'Components:  %s\n' "$(print_components "$components")"
   printf 'Provider:    %s\n' "$provider"
   printf 'Directory:   %s\n\n' "$root"
 
   case "$provider" in
-    lando) run_lando_pull "$root" "$env" ;;
-    ddev) run_ddev_pull "$root" "$env" "$site" ;;
+    lando) run_lando_pull "$root" "$env" "$components" ;;
+    ddev) run_ddev_pull "$root" "$env" "$site" "$components" ;;
     *) die "unsupported provider: $provider" ;;
   esac
 
@@ -195,10 +262,11 @@ pull_command() {
   [ "$diff_before" = "$diff_after" ] || \
     die 'provider pull changed tracked Git content; refusing to record data provenance'
 
-  record_pull_state "$state" "$provider" "$env"
+  record_pull_state "$state" "$provider" "$env" "$components"
 
   printf '\nPantheon data pull complete\n'
-  printf 'Data source: %s\n' "$env"
+  printf 'Environment: %s\n' "$env"
+  printf 'Components:  %s\n' "$(print_components "$components")"
   printf 'Git code:    unchanged\n'
 }
 

--- a/libexec/pantheon-local-status
+++ b/libexec/pantheon-local-status
@@ -64,7 +64,8 @@ provider_config_status() {
 
 status_command() {
   local root git_dir state branch tracking git_state dirty managed
-  local site env target tag provider local_name local_url data_source provider_config
+  local site env target tag provider local_name local_url provider_config
+  local legacy_data_source database_source files_source
 
   require_command git
 
@@ -106,7 +107,16 @@ status_command() {
   provider=$(state_get "$state" local.provider || true)
   local_name=$(state_get "$state" local.name || true)
   local_url=$(state_get "$state" local.url || true)
-  data_source=$(state_get "$state" data.source || true)
+  legacy_data_source=$(state_get "$state" data.source || true)
+  database_source=$(state_get "$state" data.database-source || true)
+  files_source=$(state_get "$state" data.files-source || true)
+
+  if [ -z "$database_source" ] && [ -n "$legacy_data_source" ]; then
+    database_source=$legacy_data_source
+  fi
+  if [ -z "$files_source" ] && [ -n "$legacy_data_source" ]; then
+    files_source=$legacy_data_source
+  fi
 
   if [ -n "$site" ] && [ -n "$env" ]; then
     target="$site.$env"
@@ -132,7 +142,8 @@ status_command() {
   [ -n "$tag" ] || tag='(not recorded)'
   [ -n "$local_name" ] || local_name='(not recorded)'
   [ -n "$local_url" ] || local_url='(not recorded)'
-  [ -n "$data_source" ] || data_source='(not recorded)'
+  [ -n "$database_source" ] || database_source='(not recorded)'
+  [ -n "$files_source" ] || files_source='(not recorded)'
 
   printf 'Pantheon Local Tools status\n\n'
   printf 'Directory:       %s\n' "$root"
@@ -146,7 +157,8 @@ status_command() {
   printf 'Git branch:      %s\n' "$branch"
   printf 'Git tracking:    %s\n' "$tracking"
   printf 'Git state:       %s\n' "$git_state"
-  printf 'Data source:     %s\n' "$data_source"
+  printf 'Database source: %s\n' "$database_source"
+  printf 'Files source:    %s\n' "$files_source"
 }
 
 case "${1:-}" in

--- a/tests/test-pull.sh
+++ b/tests/test-pull.sh
@@ -12,6 +12,17 @@ mkdir -p "$MOCK_BIN"
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
 assert_file_contains() { grep -F "$2" "$1" >/dev/null 2>&1 || fail "expected $1 to contain [$2]"; }
+assert_config() {
+  local file=$1 key=$2 expected=$3 actual
+  actual=$(git config --file "$file" --get "$key" 2>/dev/null || true)
+  [ "$actual" = "$expected" ] || fail "expected $key=$expected in $file, got [$actual]"
+}
+assert_config_missing() {
+  local file=$1 key=$2
+  if [ -f "$file" ] && git config --file "$file" --get "$key" >/dev/null 2>&1; then
+    fail "expected $key to be absent from $file"
+  fi
+}
 
 cat > "$MOCK_BIN/lando" <<'MOCK'
 #!/usr/bin/env bash
@@ -81,8 +92,10 @@ state_path() {
 }
 
 assert_contains "$(bash "$CLI" --help)" 'pantheon-local pull ENV'
+assert_contains "$(bash "$CLI" pull --help)" '--database-only'
+assert_contains "$(bash "$CLI" pull --help)" '--files-only'
 
-# Lando receives explicit data sources and an explicit code=none guard.
+# Lando defaults to both database and files, never code.
 LANDO="$TMP_ROOT/lando"
 create_repo "$LANDO" lando
 mkdir -p "$LANDO/subdir" "$LANDO/.git/pantheon-local-tools"
@@ -92,13 +105,29 @@ git config --file "$LANDO_STATE" local.provider lando
 
 lando_output=$(cd "$LANDO/subdir" && bash "$CLI" pull live)
 assert_contains "$lando_output" 'Environment: live'
+assert_contains "$lando_output" 'Components:  database, files'
 assert_contains "$lando_output" 'Provider:    lando'
 assert_contains "$lando_output" 'Git code:    unchanged'
 assert_file_contains "$MOCK_LOG" 'lando|pull|--code=none|--database=live|--files=live'
-[ "$(git config --file "$LANDO_STATE" --get data.source)" = live ] || fail 'Lando data source was not recorded'
-assert_contains "$(cd "$LANDO" && bash "$CLI" status)" 'Data source:     live'
+assert_config "$LANDO_STATE" data.database-source live
+assert_config "$LANDO_STATE" data.files-source live
+status_output=$(cd "$LANDO" && bash "$CLI" status)
+assert_contains "$status_output" 'Database source: live'
+assert_contains "$status_output" 'Files source:    live'
 
-# DDEV gets a one-time Pantheon site/environment override without rewriting project config.
+# Database-only Lando pull changes only database provenance and explicitly skips files.
+(cd "$LANDO" && bash "$CLI" pull test --database-only >/dev/null)
+assert_file_contains "$MOCK_LOG" 'lando|pull|--code=none|--database=test|--files=none'
+assert_config "$LANDO_STATE" data.database-source test
+assert_config "$LANDO_STATE" data.files-source live
+
+# Files-only Lando pull changes only files provenance and explicitly skips the database.
+(cd "$LANDO" && bash "$CLI" pull dev --files-only >/dev/null)
+assert_file_contains "$MOCK_LOG" 'lando|pull|--code=none|--database=none|--files=dev'
+assert_config "$LANDO_STATE" data.database-source test
+assert_config "$LANDO_STATE" data.files-source dev
+
+# DDEV gets one-time Pantheon overrides and maps component selection to skip flags.
 DDEV="$TMP_ROOT/ddev"
 create_repo "$DDEV" ddev
 mkdir -p "$DDEV/.git/pantheon-local-tools"
@@ -106,19 +135,40 @@ DDEV_STATE=$(state_path "$DDEV")
 git config --file "$DDEV_STATE" pantheon.site example-site
 git config --file "$DDEV_STATE" local.provider ddev
 
-bash "$CLI" pull --help >/dev/null
-(cd "$DDEV" && bash "$CLI" pull test >/dev/null)
-assert_file_contains "$MOCK_LOG" 'ddev|pull|pantheon|--environment=DDEV_PANTHEON_SITE=example-site,DDEV_PANTHEON_ENVIRONMENT=test|-y'
-[ "$(git config --file "$DDEV_STATE" --get data.source)" = test ] || fail 'DDEV data source was not recorded'
+(cd "$DDEV" && bash "$CLI" pull test --database-only >/dev/null)
+assert_file_contains "$MOCK_LOG" 'ddev|pull|pantheon|--environment=DDEV_PANTHEON_SITE=example-site,DDEV_PANTHEON_ENVIRONMENT=test|--skip-files|-y'
+assert_config "$DDEV_STATE" data.database-source test
+assert_config_missing "$DDEV_STATE" data.files-source
 
-# An ordinary DDEV checkout can rely on its own configured site while we override only ENV.
+(cd "$DDEV" && bash "$CLI" pull live --files-only >/dev/null)
+assert_file_contains "$MOCK_LOG" 'ddev|pull|pantheon|--environment=DDEV_PANTHEON_SITE=example-site,DDEV_PANTHEON_ENVIRONMENT=live|--skip-db|-y'
+assert_config "$DDEV_STATE" data.database-source test
+assert_config "$DDEV_STATE" data.files-source live
+
+# An ordinary DDEV checkout can rely on its own configured site while ENV is overridden.
 DDEV_UNMANAGED="$TMP_ROOT/ddev-unmanaged"
 create_repo "$DDEV_UNMANAGED" ddev
 (cd "$DDEV_UNMANAGED" && bash "$CLI" pull dev >/dev/null)
 DDEV_UNMANAGED_STATE=$(state_path "$DDEV_UNMANAGED")
 assert_file_contains "$MOCK_LOG" 'ddev|pull|pantheon|--environment=DDEV_PANTHEON_ENVIRONMENT=dev|-y'
-[ "$(git config --file "$DDEV_UNMANAGED_STATE" --get local.provider)" = ddev ] || fail 'detected DDEV provider was not recorded'
-[ "$(git config --file "$DDEV_UNMANAGED_STATE" --get data.source)" = dev ] || fail 'unmanaged DDEV data source was not recorded'
+assert_config "$DDEV_UNMANAGED_STATE" local.provider ddev
+assert_config "$DDEV_UNMANAGED_STATE" data.database-source dev
+assert_config "$DDEV_UNMANAGED_STATE" data.files-source dev
+
+# Legacy single-source provenance migrates losslessly on the first component pull.
+LEGACY="$TMP_ROOT/legacy"
+create_repo "$LEGACY" lando
+mkdir -p "$LEGACY/.git/pantheon-local-tools"
+LEGACY_STATE=$(state_path "$LEGACY")
+git config --file "$LEGACY_STATE" local.provider lando
+git config --file "$LEGACY_STATE" data.source legacy-env
+legacy_status=$(cd "$LEGACY" && bash "$CLI" status)
+assert_contains "$legacy_status" 'Database source: legacy-env'
+assert_contains "$legacy_status" 'Files source:    legacy-env'
+(cd "$LEGACY" && bash "$CLI" pull fresh-db --database-only >/dev/null)
+assert_config_missing "$LEGACY_STATE" data.source
+assert_config "$LEGACY_STATE" data.database-source fresh-db
+assert_config "$LEGACY_STATE" data.files-source legacy-env
 
 # Ambiguous provider configuration must fail unless the user chooses one explicitly.
 AMBIG="$TMP_ROOT/ambiguous"
@@ -127,7 +177,14 @@ if (cd "$AMBIG" && bash "$CLI" pull live >/dev/null 2>&1); then
   fail 'ambiguous provider configuration was accepted'
 fi
 (cd "$AMBIG" && bash "$CLI" pull live --provider lando >/dev/null)
-assert_contains "$(cd "$AMBIG" && bash "$CLI" status)" 'Data source:     live'
+AMBIG_STATUS=$(cd "$AMBIG" && bash "$CLI" status)
+assert_contains "$AMBIG_STATUS" 'Database source: live'
+assert_contains "$AMBIG_STATUS" 'Files source:    live'
+
+# Component selectors are mutually exclusive.
+if (cd "$LANDO" && bash "$CLI" pull live --database-only --files-only >/dev/null 2>&1); then
+  fail 'database-only and files-only were accepted together'
+fi
 
 # Provider failures do not create successful provenance.
 FAILED="$TMP_ROOT/failed"
@@ -138,9 +195,8 @@ if (cd "$FAILED" && bash "$CLI" pull live >/dev/null 2>&1); then
 fi
 unset MOCK_PROVIDER_FAIL
 FAILED_STATE=$(state_path "$FAILED")
-if [ -f "$FAILED_STATE" ] && git config --file "$FAILED_STATE" --get data.source >/dev/null 2>&1; then
-  fail 'failed provider pull recorded a data source'
-fi
+assert_config_missing "$FAILED_STATE" data.database-source
+assert_config_missing "$FAILED_STATE" data.files-source
 
 # If a delegated provider changes tracked code, fail and do not record provenance.
 MUTATED="$TMP_ROOT/mutated"
@@ -151,9 +207,8 @@ if (cd "$MUTATED" && bash "$CLI" pull live >/dev/null 2>&1); then
 fi
 unset MOCK_MUTATE_TRACKED
 MUTATED_STATE=$(state_path "$MUTATED")
-if [ -f "$MUTATED_STATE" ] && git config --file "$MUTATED_STATE" --get data.source >/dev/null 2>&1; then
-  fail 'tracked mutation recorded a data source'
-fi
+assert_config_missing "$MUTATED_STATE" data.database-source
+assert_config_missing "$MUTATED_STATE" data.files-source
 
 # DDEV requires the Pantheon provider integration to exist.
 DDEV_MISSING="$TMP_ROOT/ddev-missing-provider"

--- a/tests/test-status.sh
+++ b/tests/test-status.sh
@@ -56,7 +56,25 @@ assert_contains "$managed_output" 'Provider config: present'
 assert_contains "$managed_output" 'Local name:      example-site-feature1'
 assert_contains "$managed_output" 'Local URL:       http://example-site-feature1.lndo.site'
 assert_contains "$managed_output" 'Git state:       clean'
-assert_contains "$managed_output" 'Data source:     (not recorded)'
+assert_contains "$managed_output" 'Database source: (not recorded)'
+assert_contains "$managed_output" 'Files source:    (not recorded)'
+
+# Component-specific provenance remains independent.
+git config --file "$STATE" data.database-source test
+git config --file "$STATE" data.files-source live
+component_output=$(cd "$MANAGED" && bash "$CLI" status)
+assert_contains "$component_output" 'Database source: test'
+assert_contains "$component_output" 'Files source:    live'
+git config --file "$STATE" --unset-all data.database-source
+git config --file "$STATE" --unset-all data.files-source
+
+# Legacy single-source state is interpreted as both components without mutating state.
+git config --file "$STATE" data.source legacy-env
+legacy_output=$(cd "$MANAGED" && bash "$CLI" status)
+assert_contains "$legacy_output" 'Database source: legacy-env'
+assert_contains "$legacy_output" 'Files source:    legacy-env'
+[ "$(git config --file "$STATE" --get data.source)" = legacy-env ] || fail 'status mutated legacy provenance'
+git config --file "$STATE" --unset-all data.source
 
 printf 'dirty\n' >> "$MANAGED/README.md"
 dirty_output=$(cd "$MANAGED" && bash "$CLI" status)
@@ -71,6 +89,8 @@ assert_contains "$unmanaged_output" 'Pantheon:        (not recorded)'
 assert_contains "$unmanaged_output" 'Provider:        ddev (detected)'
 assert_contains "$unmanaged_output" 'Provider config: present'
 assert_contains "$unmanaged_output" 'Local name:      (not recorded)'
+assert_contains "$unmanaged_output" 'Database source: (not recorded)'
+assert_contains "$unmanaged_output" 'Files source:    (not recorded)'
 
 # The installed command is a symlink, so the router must resolve its real script directory.
 mkdir -p "$TMP_ROOT/bin"


### PR DESCRIPTION
## Summary

Add component-specific data refreshes to `pantheon-local pull` while preserving the existing full-pull default.

- keep `pantheon-local pull ENV` as database + files
- add `--database-only` for workflows that need only the database
- add `--files-only` for files-only refreshes
- map Lando selections to explicit `--database` / `--files` sources with `--code=none`
- map DDEV selections to its documented `--skip-files` / `--skip-db` flags
- reject conflicting/repeated component selectors
- record database and files provenance independently
- migrate legacy `data.source=ENV` state losslessly on the next successful component-aware pull
- keep `status` read-only while interpreting legacy single-source state compatibly
- update CLI help, architecture docs, pull/status docs, README, and cross-platform tests

## Why

Many Drupal maintenance workflows need a fresh database but not files. For example, a module update may require `drush updb` followed by `drush cex` so newly created configuration can be exported. Pulling files in that workflow adds time and network traffic without helping the change.

## Provider mappings

Lando database only:

```text
lando pull --code=none --database=ENV --files=none
```

Lando files only:

```text
lando pull --code=none --database=none --files=ENV
```

DDEV database only adds `--skip-files`; files only adds `--skip-db`.

## Provenance

New state keys are:

```text
data.database-source=ENV
data.files-source=ENV
```

A component-only pull updates only the component that was actually refreshed. Older `data.source` values are treated as both sources and migrated without losing the untouched component's history.

## Safety

The existing Git-integrity checks remain unchanged: provider success is followed by verification that Git `HEAD` and tracked content did not change before provenance is recorded. No provider authentication or token handling is added.