### PR TITLE
Make multidev URLs provider-authoritative

### DIFF
--- a/docs/multidev.md
+++ b/docs/multidev.md
@@ -9,7 +9,6 @@ The implementation relies on documented Terminus interfaces:
 - `terminus auth:whoami` verifies that Terminus has an authenticated identity.
 - `terminus site:info <site> --field=organization` resolves the site's organization when Pantheon Tag routing is configured.
 - `terminus tag:list <site> <org> --format=list` returns the Pantheon Tags for routing.
-- `terminus site:info <site> --field=framework` supplies framework metadata used only where a provider needs a framework-specific local override.
 - `terminus connection:info <site>.<env> --field=git_url` supplies the Git endpoint used for cloning.
 
 The command never constructs a Pantheon Git URL from UUID assumptions.
@@ -40,11 +39,15 @@ An explicitly requested provider start happens only after the final checkout exi
 
 ## Provider behavior
 
+Provider-owned project configuration remains authoritative. Pantheon Local Tools adds only the minimum checkout-local name override required to isolate the cloned environment.
+
+It does not rewrite base provider configuration, service definitions, proxy definitions, custom tooling, add-ons, custom Compose files, or provider-owned URL/Drush settings. This preserves project extras such as phpMyAdmin, Redis, Solr, MailHog, custom tooling, and additional services.
+
 ### Lando
 
 The project must contain `.lando.yml`.
 
-Pantheon Local Tools writes `.lando.local.yml` with an isolated local app name. For Drupal framework values, it also overrides `DRUSH_OPTIONS_URI` so a committed project-level URI cannot point Drush at a different local Lando app name.
+Pantheon Local Tools writes `.lando.local.yml` containing only the isolated local app name. The Pantheon recipe already derives its normal Drush URI from the provider proxy URL; explicit project-owned Drush/proxy configuration is left untouched rather than replaced with a hard-coded `lndo.site` value.
 
 The generated override is added to `.git/info/exclude`. The shared `.gitignore` is not modified.
 
@@ -56,13 +59,30 @@ The project must contain `.ddev/config.yaml`.
 
 Pantheon Local Tools writes `.ddev/config.local.yaml` with the isolated local project name. DDEV already treats local config overrides as local-only, and the tool additionally records the generated path in `.git/info/exclude` without modifying the project `.gitignore`.
 
+Existing additional hostnames, add-ons, and `docker-compose.*.yaml` services remain provider-owned and are not rewritten.
+
 `--start` runs `ddev start`.
+
+## Local URL metadata
+
+Pantheon Local Tools does not construct a URL from the local name plus an assumed provider suffix.
+
+After checkout creation it makes a best-effort, read-only provider inspection:
+
+- Lando application URLs are read through `lando info` when available.
+- DDEV's primary URL is read through `ddev describe -j` when available.
+
+If the provider can report a URL, it is recorded as local metadata under `.git/pantheon-local-tools/state`. If the provider is not installed, is stopped in a way that prevents inspection, or otherwise cannot report a URL, checkout creation still succeeds and no URL is invented. `pantheon-local status` will try the same read-only provider discovery later and fall back to recorded metadata when appropriate.
+
+A successful explicit `--start` performs URL discovery again after the provider starts and refreshes the recorded URL when available.
 
 ## Dry-run
 
-`--dry-run` performs the read-only Terminus lookups and prints the resolved plan without creating directories, cloning Git, or writing provider configuration.
+`--dry-run` performs the read-only Terminus lookups and prints the resolved plan without creating directories, cloning Git, writing provider configuration, or querying a local provider runtime.
 
-If provider selection is `auto`, dry-run cannot inspect the future checkout. Configure a provider or pass `--provider ddev|lando` for a fully resolved dry-run.
+Because no checkout exists yet, dry-run intentionally reports the local URL as provider-runtime information that will become available only after checkout/provider inspection. It never guesses `lndo.site`, `ddev.site`, or another domain.
+
+If provider selection is `auto`, dry-run cannot inspect the future checkout. Configure a provider or pass `--provider ddev|lando` for a fully resolved provider choice.
 
 ## Non-goals
 
@@ -73,8 +93,9 @@ The multidev command does not:
 - push code to Pantheon;
 - pull databases or files;
 - store Pantheon machine tokens;
-- overwrite existing local checkouts; or
-- create a project's base DDEV/Lando configuration when none exists.
+- overwrite existing local checkouts;
+- create a project's base DDEV/Lando configuration when none exists; or
+- replace provider-owned hostname/proxy configuration.
 
 ## Upstream references
 
@@ -83,5 +104,8 @@ The multidev command does not:
 - Pantheon `tag:list`: https://docs.pantheon.io/terminus/commands/tag-list
 - Pantheon Terminus install: https://docs.pantheon.io/terminus/install
 - Pantheon machine tokens: https://docs.pantheon.io/machine-tokens
-- DDEV configuration overrides: https://ddev.readthedocs.io/en/stable/users/configuration/config/
+- DDEV configuration overrides: https://docs.ddev.com/en/stable/users/configuration/config/
+- DDEV `describe`: https://docs.ddev.com/en/stable/users/usage/commands/
 - Lando override files: https://docs.lando.dev/landofile/index.html
+- Lando `info`: https://docs.lando.dev/cli/info.html
+- Lando Pantheon configuration: https://docs.lando.dev/plugins/pantheon/config.html

--- a/libexec/pantheon-local-core
+++ b/libexec/pantheon-local-core
@@ -5,6 +5,8 @@ PROGRAM_NAME="pantheon-local"
 DEFAULT_PROVIDER="auto"
 DEFAULT_ROOT_SUFFIX="sites/pantheon"
 MULTIDEV_TEMP=''
+SCRIPT_DIR=$(unset CDPATH; cd -- "$(dirname -- "$0")" && pwd)
+PROVIDER_URL="$SCRIPT_DIR/pantheon-local-provider-url"
 
 usage() {
   cat <<'USAGE'
@@ -441,21 +443,10 @@ add_local_exclude() {
 }
 
 write_lando_override() {
-  local checkout=$1 local_name=$2 framework=$3 file
+  local checkout=$1 local_name=$2 file
   file="$checkout/.lando.local.yml"
   [ ! -e "$file" ] || die 'refusing to overwrite existing .lando.local.yml'
-
-  {
-    printf 'name: %s\n' "$local_name"
-    case "$framework" in
-      drupal|drupal8)
-        printf '\ntooling:\n'
-        printf '  drush:\n'
-        printf '    env:\n'
-        printf '      DRUSH_OPTIONS_URI: "http://%s.lndo.site"\n' "$local_name"
-        ;;
-    esac
-  } > "$file"
+  printf 'name: %s\n' "$local_name" > "$file"
   add_local_exclude "$checkout" '.lando.local.yml'
 }
 
@@ -467,18 +458,8 @@ write_ddev_override() {
   add_local_exclude "$checkout" '.ddev/config.local.yaml'
 }
 
-provider_url() {
-  local provider=$1 local_name=$2
-  case "$provider" in
-    ddev) printf 'https://%s.ddev.site\n' "$local_name" ;;
-    lando) printf 'http://%s.lndo.site\n' "$local_name" ;;
-    auto) printf '%s\n' '(resolved after clone)' ;;
-    *) die "unsupported provider: $provider" ;;
-  esac
-}
-
 write_checkout_state() {
-  local checkout=$1 site=$2 env=$3 tag=$4 provider=$5 local_name=$6 url=$7 state
+  local checkout=$1 site=$2 env=$3 tag=$4 provider=$5 local_name=$6 state
   state="$checkout/.git/pantheon-local-tools/state"
   mkdir -p "${state%/*}"
   git config --file "$state" --replace-all pantheon.site "$site"
@@ -486,7 +467,19 @@ write_checkout_state() {
   [ -n "$tag" ] && git config --file "$state" --replace-all pantheon.tag "$tag"
   git config --file "$state" --replace-all local.provider "$provider"
   git config --file "$state" --replace-all local.name "$local_name"
+}
+
+record_checkout_url() {
+  local checkout=$1 url=$2 state
+  state="$checkout/.git/pantheon-local-tools/state"
+  [ -f "$state" ] || return 1
   git config --file "$state" --replace-all local.url "$url"
+}
+
+discover_checkout_url() {
+  local provider=$1 checkout=$2
+  [ -x "$PROVIDER_URL" ] || return 1
+  "$PROVIDER_URL" "$provider" "$checkout" 2>/dev/null
 }
 
 cleanup_multidev_temp() {
@@ -514,7 +507,7 @@ print_multidev_plan() {
 multidev_command() {
   local target='' provider_override='' group='' dry_run=false start=false
   local parsed site env route tag route_dir root base_dir destination local_name
-  local provider git_url parent tmp framework='' url
+  local provider git_url parent tmp url
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -578,7 +571,7 @@ multidev_command() {
   [ ! -e "$destination" ] || die "destination already exists: $destination"
 
   if [ "$dry_run" = true ]; then
-    url=$(provider_url "$provider" "$local_name")
+    url='(provider runtime; available after checkout)'
     print_multidev_plan 'Pantheon multidev dry-run' "$target" "$tag" "$provider" "$env" "$destination" "$local_name" "$url"
     return
   fi
@@ -599,21 +592,22 @@ multidev_command() {
   ensure_provider_project "$provider" "$tmp"
 
   case "$provider" in
-    lando)
-      framework=$(terminus_field site:info "$site" framework)
-      write_lando_override "$tmp" "$local_name" "$framework"
-      ;;
-    ddev)
-      write_ddev_override "$tmp" "$local_name"
-      ;;
+    lando) write_lando_override "$tmp" "$local_name" ;;
+    ddev) write_ddev_override "$tmp" "$local_name" ;;
   esac
 
-  url=$(provider_url "$provider" "$local_name")
-  write_checkout_state "$tmp" "$site" "$env" "$tag" "$provider" "$local_name" "$url"
+  write_checkout_state "$tmp" "$site" "$env" "$tag" "$provider" "$local_name"
 
   mv "$tmp" "$destination"
   MULTIDEV_TEMP=''
   trap - EXIT HUP INT TERM
+
+  url='(not recorded; provider runtime not inspectable yet)'
+  if url=$(discover_checkout_url "$provider" "$destination"); then
+    record_checkout_url "$destination" "$url"
+  else
+    url='(not recorded; provider runtime not inspectable yet)'
+  fi
 
   print_multidev_plan 'Created Pantheon multidev checkout' "$target" "$tag" "$provider" "$env" "$destination" "$local_name" "$url"
 
@@ -622,6 +616,11 @@ multidev_command() {
     printf '\nStarting %s...\n' "$provider"
     if ! (cd "$destination" && "$provider" start); then
       die "$provider start failed; checkout retained at $destination"
+    fi
+
+    if url=$(discover_checkout_url "$provider" "$destination"); then
+      record_checkout_url "$destination" "$url"
+      printf 'Runtime URL:  %s\n' "$url"
     fi
   fi
 }

--- a/libexec/pantheon-local-provider-url
+++ b/libexec/pantheon-local-provider-url
@@ -26,7 +26,7 @@ choose_external_url() {
 
   while IFS= read -r url; do
     [ -n "$url" ] || continue
-    url=${url%/]}
+    url=${url%/}
     is_loopback_url "$url" && continue
 
     [ -n "$first_external" ] || first_external=$url
@@ -69,6 +69,7 @@ ddev_url() {
   # the host requirements to shell tools already used by this project.
   url=$(printf '%s\n' "$output" | sed -n 's/.*"primary_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
   [ -n "$url" ] || return 1
+  url=${url%/}
   printf '%s\n' "$url"
 }
 

--- a/tests/test-multidev.sh
+++ b/tests/test-multidev.sh
@@ -18,6 +18,7 @@ fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
 assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
 assert_file_contains() { grep -F "$2" "$1" >/dev/null 2>&1 || fail "expected $1 to contain [$2]"; }
+assert_file_not_contains() { if grep -F "$2" "$1" >/dev/null 2>&1; then fail "expected $1 not to contain [$2]"; fi; }
 
 cat > "$MOCK_BIN/terminus" <<'MOCK'
 #!/usr/bin/env bash
@@ -51,21 +52,41 @@ chmod +x "$MOCK_BIN/terminus"
 cat > "$MOCK_BIN/lando" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
-[ "${1:-}" = start ] || exit 2
-printf '%s\n' "$PWD" >> "${MOCK_START_LOG:?MOCK_START_LOG is required}"
+case "${1:-}" in
+  start)
+    printf '%s\n' "$PWD" >> "${MOCK_START_LOG:?MOCK_START_LOG is required}"
+    ;;
+  info)
+    printf '%s\n' "$PWD" >> "${MOCK_INFO_LOG:?MOCK_INFO_LOG is required}"
+    [ "${MOCK_LANDO_INFO_FAIL:-false}" != true ] || exit 9
+    printf '%s\n' "${MOCK_LANDO_URLS:-[\"http://localhost:49152\",\"http://example-runtime.test/\",\"https://example-runtime.test/\"]}"
+    ;;
+  *) exit 2 ;;
+esac
 MOCK
 chmod +x "$MOCK_BIN/lando"
 
 cat > "$MOCK_BIN/ddev" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
-[ "${1:-}" = start ] || exit 2
-printf '%s\n' "$PWD" >> "${MOCK_START_LOG:?MOCK_START_LOG is required}"
+case "${1:-}" in
+  start)
+    printf '%s\n' "$PWD" >> "${MOCK_START_LOG:?MOCK_START_LOG is required}"
+    ;;
+  describe)
+    [ "${2:-}" = -j ] || exit 2
+    printf '%s\n' "$PWD" >> "${MOCK_INFO_LOG:?MOCK_INFO_LOG is required}"
+    [ "${MOCK_DDEV_INFO_FAIL:-false}" != true ] || exit 9
+    printf '%s\n' "${MOCK_DDEV_JSON:-{\"raw\":{\"primary_url\":\"https://example-ddev.test\"}}}"
+    ;;
+  *) exit 2 ;;
+esac
 MOCK
 chmod +x "$MOCK_BIN/ddev"
 
 export PATH="$MOCK_BIN:$PATH"
 export MOCK_START_LOG="$TMP_ROOT/start.log"
+export MOCK_INFO_LOG="$TMP_ROOT/info.log"
 
 create_repo() {
   local path=$1 provider=$2
@@ -75,11 +96,39 @@ create_repo() {
   git -C "$path" config user.email 'test@example.com'
   case "$provider" in
     lando)
-      printf 'name: example-site\nrecipe: pantheon\n' > "$path/.lando.yml"
+      cat > "$path/.lando.yml" <<'YAML'
+name: example-site
+recipe: pantheon
+services:
+  pma:
+    type: phpmyadmin
+  cache:
+    type: redis
+proxy:
+  pma:
+    - pma.example-project.test
+tooling:
+  custom-check:
+    service: appserver
+    cmd: php -v
+  drush:
+    env:
+      DRUSH_OPTIONS_URI: "https://provider-owned.example-project.test"
+YAML
       ;;
     ddev)
       mkdir -p "$path/.ddev"
-      printf 'name: example-ddev\ntype: drupal11\n' > "$path/.ddev/config.yaml"
+      cat > "$path/.ddev/config.yaml" <<'YAML'
+name: example-ddev
+type: drupal11
+additional_hostnames:
+  - alternate-example
+YAML
+      cat > "$path/.ddev/docker-compose.adminer.yaml" <<'YAML'
+services:
+  adminer:
+    image: adminer:latest
+YAML
       ;;
     *) fail "unknown fixture provider: $provider" ;;
   esac
@@ -102,26 +151,34 @@ bash "$CLI" config set root "$LOCAL_ROOT"
 bash "$CLI" config set provider lando
 bash "$CLI" config tag set 'Example Group' clients
 
-# Dry-run resolves Pantheon metadata and routing but makes no checkout directories.
+# Dry-run resolves Pantheon metadata and routing but does not query or guess a provider URL.
 dry_output=$(bash "$CLI" multidev example-site.feature1 --group migration --dry-run)
 assert_contains "$dry_output" 'Pantheon multidev dry-run'
 assert_contains "$dry_output" 'Tag:         Example Group'
 assert_contains "$dry_output" 'Provider:    lando'
+assert_contains "$dry_output" 'Local URL:   (provider runtime; available after checkout)'
 assert_contains "$dry_output" "$LOCAL_ROOT/clients/multidev/migration/example-site-feature1"
 [ ! -e "$LOCAL_ROOT/clients/multidev/migration/example-site-feature1" ] || fail 'dry-run created a checkout'
+[ ! -s "$MOCK_INFO_LOG" ] || fail 'dry-run queried a local provider runtime'
 
-# A real Lando checkout is cloned transactionally and receives only local overrides.
+# A real Lando checkout is cloned transactionally and receives only the local name override.
 bash "$CLI" multidev example-site.feature1 --group migration >/dev/null
 LANDO_DEST="$LOCAL_ROOT/clients/multidev/migration/example-site-feature1"
 [ -d "$LANDO_DEST/.git" ] || fail 'Lando checkout was not cloned'
 assert_eq "$(git -C "$LANDO_DEST" rev-parse --abbrev-ref HEAD)" 'feature1'
 assert_file_contains "$LANDO_DEST/.lando.local.yml" 'name: example-site-feature1'
-assert_file_contains "$LANDO_DEST/.lando.local.yml" 'DRUSH_OPTIONS_URI: "http://example-site-feature1.lndo.site"'
+assert_file_not_contains "$LANDO_DEST/.lando.local.yml" 'DRUSH_OPTIONS_URI'
 assert_file_contains "$LANDO_DEST/.git/info/exclude" '.lando.local.yml'
+assert_file_contains "$LANDO_DEST/.lando.yml" 'type: phpmyadmin'
+assert_file_contains "$LANDO_DEST/.lando.yml" 'type: redis'
+assert_file_contains "$LANDO_DEST/.lando.yml" 'custom-check:'
+assert_file_contains "$LANDO_DEST/.lando.yml" 'DRUSH_OPTIONS_URI: "https://provider-owned.example-project.test"'
+assert_eq "$(git -C "$LANDO_DEST" status --porcelain)" ''
 assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get pantheon.site)" 'example-site'
 assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get pantheon.environment)" 'feature1'
 assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get pantheon.tag)" 'Example Group'
 assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get local.provider)" 'lando'
+assert_eq "$(git config --file "$LANDO_DEST/.git/pantheon-local-tools/state" --get local.url)" 'https://example-runtime.test'
 
 if bash "$CLI" multidev example-site.feature1 --group migration >/dev/null 2>&1; then
   fail 'existing destination was overwritten or reused'
@@ -147,14 +204,20 @@ no_tag_output=$(bash "$CLI" multidev example-site.feature2 --dry-run)
 assert_contains "$no_tag_output" 'Tag:         (no configured Tag routing)'
 assert_contains "$no_tag_output" "$LOCAL_ROOT/multidev/example-site-feature2"
 
-# auto detects an unambiguous provider from the cloned project.
+# auto detects an unambiguous provider. URL discovery is best effort and never blocks checkout creation.
 bash "$CLI" config set provider auto
+export MOCK_LANDO_INFO_FAIL=true
 bash "$CLI" multidev example-site.feature2 >/dev/null
+unset MOCK_LANDO_INFO_FAIL
 AUTO_DEST="$LOCAL_ROOT/multidev/example-site-feature2"
 assert_file_contains "$AUTO_DEST/.lando.local.yml" 'name: example-site-feature2'
+assert_file_not_contains "$AUTO_DEST/.lando.local.yml" 'DRUSH_OPTIONS_URI'
 assert_eq "$(git config --file "$AUTO_DEST/.git/pantheon-local-tools/state" --get local.provider)" 'lando'
+if git config --file "$AUTO_DEST/.git/pantheon-local-tools/state" --get local.url >/dev/null 2>&1; then
+  fail 'failed provider URL discovery still recorded a URL'
+fi
 
-# DDEV is a first-class provider and writes its local override without touching shared config.
+# DDEV is first-class, preserves extra configuration, and records provider-reported URL metadata.
 export MOCK_GIT_URL="$SOURCE_DDEV"
 bash "$CLI" config set provider ddev
 bash "$CLI" multidev example-ddev.feature1 >/dev/null
@@ -162,15 +225,20 @@ DDEV_DEST="$LOCAL_ROOT/multidev/example-ddev-feature1"
 [ -f "$DDEV_DEST/.ddev/config.yaml" ] || fail 'DDEV base configuration is missing after clone'
 assert_file_contains "$DDEV_DEST/.ddev/config.local.yaml" 'name: example-ddev-feature1'
 assert_file_contains "$DDEV_DEST/.git/info/exclude" '.ddev/config.local.yaml'
+assert_file_contains "$DDEV_DEST/.ddev/config.yaml" 'alternate-example'
+assert_file_contains "$DDEV_DEST/.ddev/docker-compose.adminer.yaml" 'image: adminer:latest'
+assert_eq "$(git -C "$DDEV_DEST" status --porcelain)" ''
 assert_eq "$(git config --file "$DDEV_DEST/.git/pantheon-local-tools/state" --get local.provider)" 'ddev'
-assert_eq "$(git config --file "$DDEV_DEST/.git/pantheon-local-tools/state" --get local.url)" 'https://example-ddev-feature1.ddev.site'
+assert_eq "$(git config --file "$DDEV_DEST/.git/pantheon-local-tools/state" --get local.url)" 'https://example-ddev.test'
 
-# Runtime start is opt-in and happens only after the completed checkout is in its final path.
+# Runtime start is opt-in, happens only after finalization, and refreshes provider URL metadata.
 export MOCK_GIT_URL="$SOURCE_LANDO"
 bash "$CLI" config set provider lando
-bash "$CLI" multidev example-site.feature3 --start >/dev/null
+start_output=$(bash "$CLI" multidev example-site.feature3 --start)
 START_DEST="$LOCAL_ROOT/multidev/example-site-feature3"
 assert_file_contains "$MOCK_START_LOG" "$START_DEST"
+assert_contains "$start_output" 'Runtime URL:  https://example-runtime.test'
+assert_eq "$(git config --file "$START_DEST/.git/pantheon-local-tools/state" --get local.url)" 'https://example-runtime.test'
 
 # Failed clones must not leave the final checkout path behind.
 export MOCK_GIT_URL="$TMP_ROOT/does-not-exist"


### PR DESCRIPTION
## Summary

Remove remaining hard-coded local-provider URL assumptions from multidev creation while preserving the proven transactional clone workflow.

- make Lando checkout override name-only
- stop writing a hard-coded `DRUSH_OPTIONS_URI`
- stop constructing `*.lndo.site` and `*.ddev.site` URLs
- record a URL only when read-only provider inspection actually returns one
- refresh URL metadata after an explicit provider start
- keep checkout creation successful when runtime URL inspection is unavailable
- keep dry-run provider-neutral and avoid querying the local runtime
- preserve provider-owned services, proxies, tooling, hostnames, add-ons, and custom Compose files
- expand multidev regression fixtures with phpMyAdmin, Redis, custom Lando tooling/Drush settings, DDEV additional hostnames, and an extra Compose service

## Why

Provider configuration is the authority for local routing. A developer may use custom Lando proxy domains, a non-default Lando global domain, DDEV custom hostnames/TLDs, or other routing. Pantheon Local Tools should isolate the checkout name without replacing those decisions or merely printing a guessed URL.

Current Lando Pantheon documentation states that the recipe normally derives Drush URI from the webserver proxy URL. Explicit project-owned Drush/proxy configuration is therefore preserved rather than overwritten by this tool.

## Runtime URL behavior

After checkout creation, the tool performs the same best-effort read-only provider discovery used by `pantheon-local status`. If a URL is available, it is recorded under local Git metadata. If it is not available, no URL is invented. An explicit `--start` retries discovery after startup and records the provider-reported URL.

## Safety

This does not change Pantheon, start a runtime unless `--start` is requested, rewrite base provider configuration, or weaken the existing no-overwrite/transactional clone guarantees.