### PR TITLE
Add isolated installer smoke coverage

### DIFF
--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
+
+export HOME="$TMP_ROOT/home"
+unset XDG_CONFIG_HOME PANTHEON_LOCAL_CONFIG
+mkdir -p "$HOME"
+
+BIN_DIR="$TMP_ROOT/bin"
+install_output=$(PANTHEON_LOCAL_BIN_DIR="$BIN_DIR" bash "$REPO_ROOT/install.sh")
+
+[ -L "$BIN_DIR/pantheon-local" ] || fail 'installer did not create the command symlink'
+assert_eq "$(readlink "$BIN_DIR/pantheon-local")" "$REPO_ROOT/bin/pantheon-local"
+assert_contains "$install_output" "Installed pantheon-local -> $REPO_ROOT/bin/pantheon-local"
+assert_contains "$install_output" "Command path: $BIN_DIR/pantheon-local"
+
+expected_version="pantheon-local $(cat "$REPO_ROOT/VERSION")"
+assert_eq "$("$BIN_DIR/pantheon-local" --version)" "$expected_version"
+assert_eq "$("$BIN_DIR/pantheon-local" version)" "$expected_version"
+
+expected_config="$HOME/.config/pantheon-local-tools/config"
+assert_eq "$("$BIN_DIR/pantheon-local" config path)" "$expected_config"
+"$BIN_DIR/pantheon-local" config set provider lando
+assert_eq "$("$BIN_DIR/pantheon-local" config get provider)" 'lando'
+[ -f "$expected_config" ] || fail 'installed command did not create configuration in the isolated HOME'
+
+# Reinstalling the same checkout is idempotent.
+PANTHEON_LOCAL_BIN_DIR="$BIN_DIR" bash "$REPO_ROOT/install.sh" >/dev/null
+assert_eq "$(readlink "$BIN_DIR/pantheon-local")" "$REPO_ROOT/bin/pantheon-local"
+
+# The installer must not mutate shell startup files.
+for rc in .bashrc .bash_profile .profile .zshrc .zprofile; do
+  [ ! -e "$HOME/$rc" ] || fail "installer unexpectedly created or changed $HOME/$rc"
+done
+
+# An unrelated existing regular file is never overwritten.
+FILE_COLLISION="$TMP_ROOT/file-collision-bin"
+mkdir -p "$FILE_COLLISION"
+printf 'unrelated command\n' > "$FILE_COLLISION/pantheon-local"
+if PANTHEON_LOCAL_BIN_DIR="$FILE_COLLISION" bash "$REPO_ROOT/install.sh" >/dev/null 2>&1; then
+  fail 'installer overwrote an unrelated existing file'
+fi
+assert_eq "$(cat "$FILE_COLLISION/pantheon-local")" 'unrelated command'
+
+# An unrelated symlink is never replaced either.
+SYMLINK_COLLISION="$TMP_ROOT/symlink-collision-bin"
+mkdir -p "$SYMLINK_COLLISION"
+ln -s "$TMP_ROOT/not-this-repository" "$SYMLINK_COLLISION/pantheon-local"
+if PANTHEON_LOCAL_BIN_DIR="$SYMLINK_COLLISION" bash "$REPO_ROOT/install.sh" >/dev/null 2>&1; then
+  fail 'installer replaced an unrelated symlink'
+fi
+assert_eq "$(readlink "$SYMLINK_COLLISION/pantheon-local")" "$TMP_ROOT/not-this-repository"
+
+printf 'install tests passed\n'


### PR DESCRIPTION
## Summary

Add a clean, isolated-home smoke test for the portable clone installer.

The test verifies that `install.sh`:

- creates the expected `pantheon-local` symlink in a caller-selected bin directory
- resolves the symlink back into the repository correctly
- reports the canonical repository `VERSION`
- creates/reads configuration under the isolated HOME/XDG-default path
- is idempotent when re-run from the same checkout
- does not create shell startup files
- refuses to overwrite an unrelated regular file
- refuses to replace an unrelated symlink

## Why

Homebrew and Debian packaging will use different installation layouts, but `install.sh` remains the portable fallback. This gives Ubuntu and macOS CI a fresh-home installation contract before the real clean-machine smoke passes required for v0.1.0.