### PR TITLE
Add Debian package build path

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -1,0 +1,78 @@
+# Debian package
+
+Pantheon Local Tools can be packaged as an architecture-independent Debian package for Debian, Ubuntu, and WSL/WSL2 environments.
+
+The package contains shell code only, so its architecture is `all`.
+
+## Build
+
+From the repository root on a Debian-family system with `dpkg-deb` available:
+
+```bash
+bash packaging/debian/build-deb.sh
+```
+
+The default output is:
+
+```text
+dist/pantheon-local-tools_<VERSION>_all.deb
+```
+
+Pass an output directory as the first argument to choose another location.
+
+The package version comes directly from the repository-root `VERSION` file. Release packaging must therefore be built from the exact tagged release whose `VERSION` matches the tag.
+
+## Layout
+
+The package installs the application under:
+
+```text
+/usr/lib/pantheon-local-tools/
+```
+
+and provides the command through a relative symlink:
+
+```text
+/usr/bin/pantheon-local -> ../lib/pantheon-local-tools/bin/pantheon-local
+```
+
+Keeping `bin/`, `libexec/`, and `VERSION` together preserves the same relative module/version resolution used by the clone installer and future Homebrew formula.
+
+## Install a downloaded package
+
+For a `.deb` downloaded from a GitHub Release:
+
+```bash
+sudo apt install ./pantheon-local-tools_<VERSION>_all.deb
+```
+
+Using `apt install ./...` is preferred over invoking `dpkg -i` directly because APT handles declared dependencies.
+
+## Runtime dependencies
+
+The package declares:
+
+- `bash`
+- `git`
+
+Provider-specific tools are intentionally not package dependencies. Install Terminus, DDEV, or Lando according to the workflows you actually use and their upstream installation guidance.
+
+## User state
+
+Package installation does not create Pantheon Local Tools user configuration, provider project files, or Pantheon credentials.
+
+User configuration remains under the existing XDG/home path, normally:
+
+```text
+~/.config/pantheon-local-tools/config
+```
+
+Package removal does not own that file and therefore must not delete it. Checkout-local state under `.git/pantheon-local-tools/` is likewise outside package ownership.
+
+## Signed APT repository
+
+A downloadable `.deb` and a hosted APT repository are separate distribution layers.
+
+The initial package can be attached directly to a GitHub Release. A later signed APT repository can add normal `apt update` / `apt install pantheon-local-tools` upgrade discovery after repository hosting, signing/keyring policy, metadata publication, and rotation/recovery procedures are established.
+
+The hosted APT repository is intentionally not required to ship the first `.deb`.

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME='pantheon-local-tools Debian builder'
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
+OUTPUT_DIR=${1:-"$REPO_ROOT/dist"}
+VERSION_FILE="$REPO_ROOT/VERSION"
+
+require_command dpkg-deb
+require_command install
+
+[ -f "$VERSION_FILE" ] || die "VERSION file not found: $VERSION_FILE"
+VERSION=$(cat "$VERSION_FILE")
+[ -n "$VERSION" ] || die 'VERSION cannot be empty'
+case "$VERSION" in
+  *$'\n'*|*$'\r'*) die 'VERSION must be a single line' ;;
+esac
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR=$(cd "$OUTPUT_DIR" && pwd)
+PACKAGE_FILE="$OUTPUT_DIR/pantheon-local-tools_${VERSION}_all.deb"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT HUP INT TERM
+
+APP_ROOT="$STAGE/usr/lib/pantheon-local-tools"
+DOC_ROOT="$STAGE/usr/share/doc/pantheon-local-tools"
+CONTROL_ROOT="$STAGE/DEBIAN"
+
+install -d "$APP_ROOT/bin" "$APP_ROOT/libexec" "$STAGE/usr/bin" "$DOC_ROOT" "$CONTROL_ROOT"
+install -m 0755 "$REPO_ROOT/bin/pantheon-local" "$APP_ROOT/bin/pantheon-local"
+install -m 0755 "$REPO_ROOT/libexec/pantheon-local-core" "$APP_ROOT/libexec/pantheon-local-core"
+install -m 0755 "$REPO_ROOT/libexec/pantheon-local-provider-url" "$APP_ROOT/libexec/pantheon-local-provider-url"
+install -m 0755 "$REPO_ROOT/libexec/pantheon-local-pull" "$APP_ROOT/libexec/pantheon-local-pull"
+install -m 0755 "$REPO_ROOT/libexec/pantheon-local-status" "$APP_ROOT/libexec/pantheon-local-status"
+install -m 0644 "$VERSION_FILE" "$APP_ROOT/VERSION"
+install -m 0644 "$REPO_ROOT/LICENSE" "$DOC_ROOT/copyright"
+install -m 0644 "$REPO_ROOT/README.md" "$DOC_ROOT/README.md"
+
+ln -s '../lib/pantheon-local-tools/bin/pantheon-local' "$STAGE/usr/bin/pantheon-local"
+
+cat > "$CONTROL_ROOT/control" <<EOF
+Package: pantheon-local-tools
+Version: $VERSION
+Section: devel
+Priority: optional
+Architecture: all
+Maintainer: zevarix <zevarix@users.noreply.github.com>
+Depends: bash, git
+Homepage: https://github.com/zevarix/pantheon-local-tools
+Description: Provider-neutral local development helpers for Pantheon
+ Pantheon Local Tools provides a consistent CLI for Pantheon multidev
+ checkout, data pull, and local status workflows with DDEV and Lando.
+EOF
+
+chmod 0755 "$CONTROL_ROOT"
+chmod 0644 "$CONTROL_ROOT/control"
+
+dpkg-deb --root-owner-group --build "$STAGE" "$PACKAGE_FILE" >/dev/null
+printf '%s\n' "$PACKAGE_FILE"

--- a/tests/test-debian-package.sh
+++ b/tests/test-debian-package.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
+
+if ! command -v dpkg-deb >/dev/null 2>&1; then
+  printf 'debian package tests skipped (dpkg-deb unavailable)\n'
+  exit 0
+fi
+
+PACKAGE=$(bash "$REPO_ROOT/packaging/debian/build-deb.sh" "$TMP_ROOT/dist")
+[ -f "$PACKAGE" ] || fail 'Debian builder did not create a package'
+
+VERSION=$(cat "$REPO_ROOT/VERSION")
+assert_eq "$(dpkg-deb -f "$PACKAGE" Package)" 'pantheon-local-tools'
+assert_eq "$(dpkg-deb -f "$PACKAGE" Version)" "$VERSION"
+assert_eq "$(dpkg-deb -f "$PACKAGE" Architecture)" 'all'
+assert_eq "$(dpkg-deb -f "$PACKAGE" Depends)" 'bash, git'
+
+EXTRACT="$TMP_ROOT/root"
+mkdir -p "$EXTRACT"
+dpkg-deb -x "$PACKAGE" "$EXTRACT"
+
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/bin/pantheon-local" ] || fail 'packaged command is missing or not executable'
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-core" ] || fail 'packaged core module is missing or not executable'
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-provider-url" ] || fail 'packaged URL module is missing or not executable'
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-pull" ] || fail 'packaged pull module is missing or not executable'
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-status" ] || fail 'packaged status module is missing or not executable'
+[ -f "$EXTRACT/usr/lib/pantheon-local-tools/VERSION" ] || fail 'packaged VERSION is missing'
+[ -L "$EXTRACT/usr/bin/pantheon-local" ] || fail 'packaged command link is missing'
+assert_eq "$(readlink "$EXTRACT/usr/bin/pantheon-local")" '../lib/pantheon-local-tools/bin/pantheon-local'
+
+expected="pantheon-local $VERSION"
+assert_eq "$("$EXTRACT/usr/bin/pantheon-local" --version)" "$expected"
+assert_eq "$("$EXTRACT/usr/bin/pantheon-local" version)" "$expected"
+
+export HOME="$TMP_ROOT/home"
+unset XDG_CONFIG_HOME PANTHEON_LOCAL_CONFIG
+mkdir -p "$HOME"
+assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config path)" "$HOME/.config/pantheon-local-tools/config"
+"$EXTRACT/usr/bin/pantheon-local" config set provider ddev
+assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config get provider)" 'ddev'
+
+# Packaging must not ship user state, provider project configuration, or credentials.
+if find "$EXTRACT" -type f -o -type l | grep -E '/\.config/|/\.lando|/\.ddev|pantheon-local-tools/state|machine-token' >/dev/null 2>&1; then
+  fail 'Debian package unexpectedly contains user/provider state'
+fi
+
+printf 'debian package tests passed\n'


### PR DESCRIPTION
## Summary

Add a native architecture-independent Debian package build path for Debian, Ubuntu, and WSL/WSL2 users.

- build `pantheon-local-tools_<VERSION>_all.deb` directly from the repository-root `VERSION`
- install the application below `/usr/lib/pantheon-local-tools`
- expose `/usr/bin/pantheon-local` through a relative symlink so existing module/version resolution remains intact
- declare only `bash` and `git` as package dependencies
- keep Terminus/DDEV/Lando optional and workflow-specific
- include license/README documentation
- test package metadata, file layout, executable permissions, symlink resolution, version reporting, isolated user config, and absence of bundled user/provider state
- document direct `.deb` installation and the future signed APT-repository boundary

## CI

On Ubuntu, the normal test suite builds and extracts the `.deb` with `dpkg-deb`. On macOS, the packaging scripts still receive syntax/ShellCheck coverage while the `dpkg-deb` runtime test reports a clean skip.

## Distribution boundary

This PR creates the package artifact format, not a hosted APT repository. A tagged release can attach the `.deb` directly. Signed APT metadata/hosting/key rotation remains the separate follow-up tracked in #9.