### PR TITLE
Add Homebrew formula packaging path

### DIFF
--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,100 @@
+# Homebrew packaging
+
+Pantheon Local Tools is designed to be published through a small external Homebrew tap after a tagged release exists.
+
+The intended tap repository is:
+
+```text
+zevarix/homebrew-tap
+```
+
+Homebrew maps that GitHub repository to the short tap name `zevarix/tap`. The formula should live at:
+
+```text
+Formula/pantheon-local-tools.rb
+```
+
+## User installation
+
+After the first tagged release and tap publication, the preferred one-command installation is:
+
+```bash
+brew install zevarix/tap/pantheon-local-tools
+```
+
+The explicit formula reference trusts only that formula rather than the entire third-party tap.
+
+Users may also tap first and then install:
+
+```bash
+brew tap zevarix/tap
+brew install pantheon-local-tools
+```
+
+## Formula layout
+
+The formula installs the source payload beneath Homebrew's formula `libexec` directory:
+
+```text
+libexec/
+  bin/pantheon-local
+  libexec/pantheon-local-core
+  libexec/pantheon-local-provider-url
+  libexec/pantheon-local-pull
+  libexec/pantheon-local-status
+  VERSION
+```
+
+Homebrew then links only `libexec/bin/pantheon-local` into the formula `bin` directory. This preserves the same relative `bin` → `libexec` → `VERSION` resolution contract used by the clone installer and Debian package.
+
+No provider configuration, user configuration, checkout state, or Pantheon credentials are generated during installation.
+
+## Render a release formula
+
+`render-formula.sh` takes four values:
+
+```bash
+bash packaging/homebrew/render-formula.sh VERSION URL SHA256 OUTPUT
+```
+
+For a release, `VERSION` must equal the repository-root `VERSION` and the `vVERSION` Git tag. `URL` should be the immutable GitHub release source archive URL and `SHA256` must be calculated from that exact archive.
+
+Example shape after `v0.1.0` exists:
+
+```bash
+VERSION=0.1.0
+URL="https://github.com/zevarix/pantheon-local-tools/archive/refs/tags/v${VERSION}.tar.gz"
+SHA256="<verified release archive sha256>"
+bash packaging/homebrew/render-formula.sh \
+  "$VERSION" "$URL" "$SHA256" \
+  Formula/pantheon-local-tools.rb
+```
+
+Do not publish a formula that points at `main`, a branch archive, or an unverified checksum.
+
+## Validation
+
+The repository test suite performs a local Homebrew installation on macOS CI from a generated local source archive. It verifies:
+
+- formula Ruby syntax;
+- source checksum enforcement;
+- the Homebrew `libexec` layout;
+- command/module executability;
+- `pantheon-local version` and `--version` consistency;
+- the formula `test do` block; and
+- user configuration remaining outside Homebrew-owned paths.
+
+The test skips on hosts where Homebrew is unavailable, while the renderer still receives normal shell syntax and ShellCheck validation.
+
+Before publishing the real tap formula, validate the final release URL/checksum with current Homebrew tooling, including a build-from-source install, `brew test`, `brew audit --strict --new --online`, and `brew style`.
+
+## Upgrade and uninstall
+
+A real release candidate is not complete until the tap has been exercised for:
+
+- clean installation;
+- upgrade from a previous package revision/version where applicable;
+- `brew test` after installation/upgrade; and
+- uninstall without deleting `~/.config/pantheon-local-tools/` or checkout-local `.git/pantheon-local-tools/` metadata.
+
+Homebrew owns installed package files only. User configuration and checkout state remain outside package ownership.

--- a/packaging/homebrew/render-formula.sh
+++ b/packaging/homebrew/render-formula.sh
@@ -27,6 +27,7 @@ escape_ruby_string() {
 
 VERSION_ESCAPED=$(escape_ruby_string "$VERSION")
 URL_ESCAPED=$(escape_ruby_string "$URL")
+SHA256_NORMALIZED=$(printf '%s' "$SHA256" | tr '[:upper:]' '[:lower:]')
 OUTPUT_DIR=${OUTPUT%/*}
 [ "$OUTPUT_DIR" != "$OUTPUT" ] || OUTPUT_DIR='.'
 mkdir -p "$OUTPUT_DIR"
@@ -37,7 +38,7 @@ class PantheonLocalTools < Formula
   homepage "https://github.com/zevarix/pantheon-local-tools"
   url "$URL_ESCAPED"
   version "$VERSION_ESCAPED"
-  sha256 "${SHA256,,}"
+  sha256 "$SHA256_NORMALIZED"
   license "MIT"
 
   def install

--- a/packaging/homebrew/render-formula.sh
+++ b/packaging/homebrew/render-formula.sh
@@ -41,6 +41,8 @@ class PantheonLocalTools < Formula
   sha256 "$SHA256_NORMALIZED"
   license "MIT"
 
+  depends_on "git"
+
   def install
     libexec.install "bin", "libexec", "VERSION", "LICENSE", "README.md"
     bin.install_symlink libexec/"bin/pantheon-local"
@@ -48,7 +50,10 @@ class PantheonLocalTools < Formula
 
   test do
     assert_match "pantheon-local #{version}", shell_output("#{bin}/pantheon-local --version")
-    assert_match "pantheon-local #{version}", shell_output("#{bin}/pantheon-local version")
+
+    ENV["PANTHEON_LOCAL_CONFIG"] = testpath/"config"
+    system bin/"pantheon-local", "config", "set", "provider", "lando"
+    assert_equal "lando", shell_output("#{bin}/pantheon-local config get provider").strip
   end
 end
 EOF

--- a/packaging/homebrew/render-formula.sh
+++ b/packaging/homebrew/render-formula.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME='pantheon-local-tools Homebrew renderer'
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+[ "$#" -eq 4 ] || die 'usage: render-formula.sh VERSION URL SHA256 OUTPUT'
+VERSION=$1
+URL=$2
+SHA256=$3
+OUTPUT=$4
+
+[ -n "$VERSION" ] || die 'VERSION cannot be empty'
+[ -n "$URL" ] || die 'URL cannot be empty'
+printf '%s\n' "$SHA256" | LC_ALL=C grep -Eq '^[0-9a-fA-F]{64}$' || die 'SHA256 must contain exactly 64 hexadecimal characters'
+case "$VERSION$URL$OUTPUT" in
+  *$'\n'*|*$'\r'*) die 'arguments cannot contain newlines' ;;
+esac
+
+escape_ruby_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+VERSION_ESCAPED=$(escape_ruby_string "$VERSION")
+URL_ESCAPED=$(escape_ruby_string "$URL")
+OUTPUT_DIR=${OUTPUT%/*}
+[ "$OUTPUT_DIR" != "$OUTPUT" ] || OUTPUT_DIR='.'
+mkdir -p "$OUTPUT_DIR"
+
+cat > "$OUTPUT" <<EOF
+class PantheonLocalTools < Formula
+  desc "Provider-neutral local development helpers for Pantheon"
+  homepage "https://github.com/zevarix/pantheon-local-tools"
+  url "$URL_ESCAPED"
+  version "$VERSION_ESCAPED"
+  sha256 "${SHA256,,}"
+  license "MIT"
+
+  def install
+    libexec.install "bin", "libexec", "VERSION", "LICENSE", "README.md"
+    bin.install_symlink libexec/"bin/pantheon-local"
+  end
+
+  test do
+    assert_match "pantheon-local #{version}", shell_output("#{bin}/pantheon-local --version")
+    assert_match "pantheon-local #{version}", shell_output("#{bin}/pantheon-local version")
+  end
+end
+EOF
+
+printf '%s\n' "$OUTPUT"

--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -4,10 +4,18 @@ set -euo pipefail
 REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
 TMP_ROOT=$(mktemp -d)
 FORMULA_NAME='pantheon-local-tools'
+TAP='zevarix-ci/pantheon-local-tools-ci'
+FULL_FORMULA="$TAP/$FORMULA_NAME"
 
 cleanup() {
-  if command -v brew >/dev/null 2>&1 && brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
-    HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --force "$FORMULA_NAME" >/dev/null 2>&1 || true
+  if command -v brew >/dev/null 2>&1; then
+    if brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
+      HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+        brew uninstall --force "$FORMULA_NAME" >/dev/null 2>&1 || true
+    fi
+    if brew tap | grep -Fx "$TAP" >/dev/null 2>&1; then
+      HOMEBREW_NO_AUTO_UPDATE=1 brew untap "$TAP" >/dev/null 2>&1 || true
+    fi
   fi
   rm -rf "$TMP_ROOT"
 }
@@ -24,20 +32,28 @@ fi
 if brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
   fail "$FORMULA_NAME is already installed in the test environment"
 fi
+if brew tap | grep -Fx "$TAP" >/dev/null 2>&1; then
+  fail "$TAP is already present in the test environment"
+fi
 
 VERSION=$(cat "$REPO_ROOT/VERSION")
 ARCHIVE="$TMP_ROOT/pantheon-local-tools-$VERSION.tar.gz"
-FORMULA="$TMP_ROOT/pantheon-local-tools.rb"
 
 git -C "$REPO_ROOT" archive --format=tar HEAD | gzip -n > "$ARCHIVE"
 SHA256=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 URL="file://$ARCHIVE"
 
+HOMEBREW_NO_AUTO_UPDATE=1 brew tap-new --no-git "$TAP" >/dev/null
+TAP_ROOT=$(brew --repository "$TAP")
+FORMULA="$TAP_ROOT/Formula/pantheon-local-tools.rb"
+
 bash "$REPO_ROOT/packaging/homebrew/render-formula.sh" "$VERSION" "$URL" "$SHA256" "$FORMULA" >/dev/null
 ruby -c "$FORMULA" >/dev/null
 
-HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula --build-from-source "$FORMULA" >/dev/null
-HOMEBREW_NO_AUTO_UPDATE=1 brew test "$FORMULA" >/dev/null
+HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+  brew install --build-from-source "$FULL_FORMULA" >/dev/null
+HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+  brew test "$FULL_FORMULA" >/dev/null
 
 PREFIX=$(brew --prefix "$FORMULA_NAME")
 [ -x "$PREFIX/libexec/bin/pantheon-local" ] || fail 'Homebrew command payload is missing'

--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+FORMULA_NAME='pantheon-local-tools'
+
+cleanup() {
+  if command -v brew >/dev/null 2>&1 && brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
+    HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --force "$FORMULA_NAME" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
+
+if ! command -v brew >/dev/null 2>&1; then
+  printf 'homebrew package tests skipped (brew unavailable)\n'
+  exit 0
+fi
+
+if brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
+  fail "$FORMULA_NAME is already installed in the test environment"
+fi
+
+VERSION=$(cat "$REPO_ROOT/VERSION")
+ARCHIVE="$TMP_ROOT/pantheon-local-tools-$VERSION.tar.gz"
+FORMULA="$TMP_ROOT/pantheon-local-tools.rb"
+
+git -C "$REPO_ROOT" archive --format=tar HEAD | gzip -n > "$ARCHIVE"
+SHA256=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+URL="file://$ARCHIVE"
+
+bash "$REPO_ROOT/packaging/homebrew/render-formula.sh" "$VERSION" "$URL" "$SHA256" "$FORMULA" >/dev/null
+ruby -c "$FORMULA" >/dev/null
+
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula --build-from-source "$FORMULA" >/dev/null
+HOMEBREW_NO_AUTO_UPDATE=1 brew test "$FORMULA" >/dev/null
+
+PREFIX=$(brew --prefix "$FORMULA_NAME")
+[ -x "$PREFIX/libexec/bin/pantheon-local" ] || fail 'Homebrew command payload is missing'
+[ -x "$PREFIX/libexec/libexec/pantheon-local-core" ] || fail 'Homebrew core module is missing'
+[ -x "$PREFIX/libexec/libexec/pantheon-local-provider-url" ] || fail 'Homebrew provider URL module is missing'
+[ -x "$PREFIX/libexec/libexec/pantheon-local-pull" ] || fail 'Homebrew pull module is missing'
+[ -x "$PREFIX/libexec/libexec/pantheon-local-status" ] || fail 'Homebrew status module is missing'
+[ -f "$PREFIX/libexec/VERSION" ] || fail 'Homebrew VERSION is missing'
+
+expected="pantheon-local $VERSION"
+assert_eq "$(pantheon-local --version)" "$expected"
+assert_eq "$(pantheon-local version)" "$expected"
+
+TEST_HOME="$TMP_ROOT/home"
+mkdir -p "$TEST_HOME"
+assert_eq "$(HOME="$TEST_HOME" pantheon-local config path)" "$TEST_HOME/.config/pantheon-local-tools/config"
+
+printf 'homebrew package tests passed\n'


### PR DESCRIPTION
## Summary

Prepare Pantheon Local Tools for a first-class Homebrew tap without publishing a release-specific formula prematurely.

- add a Bash 3.2-compatible formula renderer that takes exact VERSION/URL/SHA256 inputs
- install the application under Homebrew `libexec` and link only `pantheon-local` into `bin`
- preserve the same relative dispatcher/module/VERSION layout used by clone and Debian installs
- add a real local Homebrew install/test/uninstall smoke test on macOS CI
- generate a checksummed local source archive in CI so formula installation is tested before a release tag exists
- document the intended `zevarix/homebrew-tap` / `zevarix/tap` publication path
- require immutable tagged release URL + verified SHA256 for the final formula
- document final `brew test`, audit, style, upgrade, and uninstall gates

## Intended user install

After v0.1.0 is tagged and the tap formula is published:

```text
brew install zevarix/tap/pantheon-local-tools
```

Current Homebrew guidance recommends direct installation from a third-party tap when whole-tap trust is unnecessary.

## Release boundary

This PR deliberately does not embed a fake release checksum or point a formula at `main`. The final `Formula/pantheon-local-tools.rb` is rendered only after the immutable `v0.1.0` source archive exists and its SHA256 has been verified.