### PR TITLE
Document and test release distribution flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ pantheon-local --version
 
 The documented command/configuration and safety guarantees for the `0.1.x` line are defined in [`docs/compatibility.md`](docs/compatibility.md). Patch releases should preserve that contract; intentionally breaking pre-1.0 changes belong in a future minor release with release notes/migration guidance.
 
-## Install from a clone
+## Installation and distribution
+
+### Install from a clone
+
+The clone installer is the currently usable portable installation path while `v0.1.0` release validation is completed:
 
 ```bash
 git clone git@github.com:zevarix/pantheon-local-tools.git
@@ -230,9 +234,37 @@ cd pantheon-local-tools
 ./install.sh
 ```
 
-The installer creates a symlink at `~/.local/bin/pantheon-local` by default and refuses to overwrite an unrelated existing command. Set `PANTHEON_LOCAL_BIN_DIR` to choose a different destination.
+The installer creates a symlink at `~/.local/bin/pantheon-local` by default and refuses to overwrite an unrelated existing command. Set `PANTHEON_LOCAL_BIN_DIR` to choose a different destination. It does not edit shell startup files.
 
-A Homebrew installation path is planned for the first shareable tagged release. A native architecture-independent Debian package is also planned for Linux/WSL, with a signed APT repository following after the package layout and upgrade behavior are proven. The clone installer remains the portable fallback for macOS, Linux, WSL, contributors, and CI.
+### Homebrew
+
+The Homebrew formula path is implemented and exercised by macOS CI through a real temporary tap. After the first tagged release and publication of `zevarix/homebrew-tap`, the intended end-user command is:
+
+```bash
+brew install zevarix/tap/pantheon-local-tools
+```
+
+The publishable formula is deliberately generated only after the immutable release source artifact URL and SHA256 are available. See [`packaging/homebrew/README.md`](packaging/homebrew/README.md).
+
+### Debian / Ubuntu / WSL
+
+An architecture-independent Debian package builder is implemented and tested on Ubuntu:
+
+```bash
+bash packaging/debian/build-deb.sh
+```
+
+Tagged releases may attach `pantheon-local-tools_<VERSION>_all.deb`. A downloaded package installs with:
+
+```bash
+sudo apt install ./pantheon-local-tools_<VERSION>_all.deb
+```
+
+The package installs application files under `/usr/lib/pantheon-local-tools`, exposes `/usr/bin/pantheon-local`, and leaves user configuration/checkouts outside package ownership. Real WSL install/upgrade/uninstall validation remains a release gate. A hosted signed APT repository is a later distribution layer, not a prerequisite for the first `.deb`. See [`packaging/debian/README.md`](packaging/debian/README.md).
+
+The clone installer remains supported as the portable fallback for macOS, Linux, WSL, contributors, and CI even after package-manager distribution is published.
+
+Maintainers should follow [`docs/releasing.md`](docs/releasing.md) for the tag, deterministic source archive, checksums, GitHub Release, Homebrew formula, and Debian artifact sequence.
 
 ## Development
 
@@ -249,10 +281,10 @@ done
 Run ShellCheck when available:
 
 ```bash
-shellcheck bin/pantheon-local libexec/pantheon-local-* install.sh tests/test-*.sh
+shellcheck bin/pantheon-local libexec/pantheon-local-* install.sh tests/test-*.sh packaging/debian/*.sh packaging/homebrew/*.sh packaging/release/*.sh
 ```
 
-CI runs syntax validation, ShellCheck, and the test suite on both Ubuntu and macOS. WSL behavior is covered by Linux-path contract tests and will receive a real WSL integration pass before the first tagged release.
+CI runs syntax validation, ShellCheck, and the full shell integration suite on both Ubuntu and macOS. The suite includes isolated-home installer coverage, provider mocks, deterministic release-source packaging, Ubuntu `.deb` layout validation, and macOS Homebrew temporary-tap installation. WSL behavior is covered by Linux-path contract tests and still requires a real WSL integration pass before the first tagged release.
 
 ## Contributing
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,168 @@
+# Release procedure
+
+This document is the maintainer procedure for publishing Pantheon Local Tools. It complements the compatibility contract and provider-validation tracker; it does not waive any open release blocker.
+
+## Release gates
+
+Before tagging a release:
+
+1. `main` must contain the intended release code and required CI must be green.
+2. The release tracker must show the required real provider/host integration passes complete.
+3. `VERSION` must contain the exact release version, without a development suffix for a final release.
+4. `pantheon-local version` and `pantheon-local --version` must report that same version.
+5. The public-content audit must be current and free of private organization/site/account/UUID/path/state values.
+6. The documented compatibility contract must match the release behavior.
+7. Clean install checks required by the release tracker must be complete.
+
+Do not tag first and hope to repair the release afterward. Prepare the release version through an ordinary reviewed PR.
+
+## 1. Prepare the release commit
+
+For `v0.1.0`, update the repository-root `VERSION` from the development value to:
+
+```text
+0.1.0
+```
+
+Run the full repository validation matrix and merge only when required checks pass.
+
+After merge, verify the exact release commit locally or through canonical GitHub state. When using Git locally, prefer explicit output without a pager for review commands, for example:
+
+```bash
+git --no-pager status --short --branch
+git --no-pager log -1 --oneline
+cat VERSION
+```
+
+The release working tree should be clean and the checked-out commit should be the intended `main` release commit.
+
+## 2. Create the tag
+
+Create the exact `vVERSION` tag only after the release commit is final:
+
+```bash
+VERSION=$(cat VERSION)
+git tag -a "v$VERSION" -m "Pantheon Local Tools v$VERSION"
+git push origin "v$VERSION"
+```
+
+Read the tag back and verify it resolves to the intended release commit.
+
+The release artifact builder refuses a normal release build unless `vVERSION` exists and points at the current `HEAD`. CI/testing can opt into untagged builds only through the explicit `PANTHEON_LOCAL_RELEASE_ALLOW_UNTAGGED=1` test boundary.
+
+## 3. Build deterministic release artifacts
+
+From the exact tagged checkout:
+
+```bash
+bash packaging/release/build-artifacts.sh
+```
+
+The builder creates under `dist/`:
+
+```text
+pantheon-local-tools-<VERSION>.tar.gz
+SHA256SUMS
+```
+
+On Debian-family hosts with `dpkg-deb` available it also creates:
+
+```text
+pantheon-local-tools_<VERSION>_all.deb
+```
+
+The source archive is produced with `git archive` and `gzip -n` using a stable top-level directory. `SHA256SUMS` records the source archive and every package artifact built in that run.
+
+Build twice from the same exact ref if release confidence requires an additional reproducibility check; the source archive checksum must match.
+
+## 4. Create the GitHub Release
+
+Create a GitHub Release for the exact `vVERSION` tag and attach at least:
+
+- `pantheon-local-tools-<VERSION>.tar.gz`;
+- `SHA256SUMS`; and
+- `pantheon-local-tools_<VERSION>_all.deb` when the Debian artifact is part of the release.
+
+Do not upload artifacts built from a different commit than the release tag.
+
+Release notes should summarize user-visible commands/behavior, compatibility guarantees, supported providers/hosts actually validated, known limitations, and installation options. Avoid environment-specific validation details or private identifiers.
+
+After upload, download the published artifacts again and verify their SHA256 values against `SHA256SUMS` before using any artifact URL in package metadata.
+
+## 5. Publish the Homebrew formula
+
+The public tap is intended to be:
+
+```text
+zevarix/homebrew-tap
+```
+
+with the short tap name:
+
+```text
+zevarix/tap
+```
+
+Use the exact published release source asset URL and its verified SHA256 to render the formula:
+
+```bash
+VERSION=0.1.0
+URL="https://github.com/zevarix/pantheon-local-tools/releases/download/v${VERSION}/pantheon-local-tools-${VERSION}.tar.gz"
+SHA256="<verified published source artifact sha256>"
+
+bash packaging/homebrew/render-formula.sh \
+  "$VERSION" "$URL" "$SHA256" \
+  Formula/pantheon-local-tools.rb
+```
+
+Commit the generated formula to `Formula/pantheon-local-tools.rb` in `zevarix/homebrew-tap`.
+
+Never publish a formula that points to `main`, an unverified archive, or a placeholder checksum.
+
+Validate the published formula with current Homebrew tooling, including the repository's required equivalents of:
+
+```bash
+brew install --build-from-source zevarix/tap/pantheon-local-tools
+brew test zevarix/tap/pantheon-local-tools
+brew audit --strict --new --online zevarix/tap/pantheon-local-tools
+brew style zevarix/tap/pantheon-local-tools
+```
+
+Then verify the installed `pantheon-local --version`, configuration path/write/read behavior, and uninstall behavior.
+
+The repository CI already proves the same formula layout through an isolated temporary tap before publication; the released tap check proves the actual end-user distribution path.
+
+## 6. Validate the Debian release artifact
+
+For a downloaded release package on Ubuntu/Debian:
+
+```bash
+sudo apt install ./pantheon-local-tools_<VERSION>_all.deb
+pantheon-local --version
+```
+
+Verify user configuration remains outside package ownership and survives package removal/reinstallation.
+
+Before advertising upgrade support, exercise a real previous-version -> current-version package upgrade. WSL/WSL2 requires its own real validation pass; Ubuntu CI is useful contract evidence but is not a substitute for WSL runtime proof.
+
+A signed hosted APT repository is a separate distribution layer and does not become implied merely because a `.deb` exists.
+
+## 7. Post-release verification
+
+After publication, verify:
+
+- GitHub tag -> release commit identity;
+- published release artifact checksums;
+- `pantheon-local --version` through each advertised install method;
+- clean Homebrew installation from `zevarix/tap`;
+- Homebrew test and uninstall;
+- Debian installation when shipped;
+- configuration remains user-owned;
+- no provider/project state is created merely by package installation; and
+- the portable clone installer remains documented and functional.
+
+Only then mark the corresponding release-tracker items complete.
+
+## Recovery rule
+
+If a published artifact or package metadata is wrong, preserve evidence and correct it explicitly. Do not silently move an existing release tag to different source bytes or replace a checksum without documenting the correction. Prefer a new patch release when users may already have consumed the published artifact.

--- a/packaging/release/build-artifacts.sh
+++ b/packaging/release/build-artifacts.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME='pantheon-local-tools release builder'
+
+fail() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+sha256_file() {
+  local file=$1
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    fail 'required SHA256 tool not found: install shasum or sha256sum'
+  fi
+}
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
+VERSION_FILE="$REPO_ROOT/VERSION"
+[ -f "$VERSION_FILE" ] || fail "VERSION not found: $VERSION_FILE"
+VERSION=$(cat "$VERSION_FILE")
+[ -n "$VERSION" ] || fail 'VERSION cannot be empty'
+printf '%s\n' "$VERSION" | LC_ALL=C grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$' || \
+  fail "VERSION is not a supported SemVer-like value: $VERSION"
+
+require_command git
+require_command gzip
+
+OUT_DIR=${1:-"$REPO_ROOT/dist"}
+case "$OUT_DIR" in
+  /*) ;;
+  *) OUT_DIR="$REPO_ROOT/$OUT_DIR" ;;
+esac
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd -- "$OUT_DIR" && pwd -P)
+
+HEAD_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+TAG="v$VERSION"
+ARCHIVE_REF=$TAG
+
+if [ "${PANTHEON_LOCAL_RELEASE_ALLOW_UNTAGGED:-0}" = '1' ]; then
+  ARCHIVE_REF=$HEAD_SHA
+else
+  TAG_SHA=$(git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$TAG^{commit}" 2>/dev/null || true)
+  [ -n "$TAG_SHA" ] || fail "release tag does not exist: $TAG"
+  [ "$TAG_SHA" = "$HEAD_SHA" ] || fail "release tag $TAG does not point at current HEAD $HEAD_SHA"
+fi
+
+SOURCE_NAME="pantheon-local-tools-$VERSION.tar.gz"
+SOURCE_PATH="$OUT_DIR/$SOURCE_NAME"
+TMP_SOURCE="$OUT_DIR/.$SOURCE_NAME.tmp.$$"
+trap 'rm -f "$TMP_SOURCE"' EXIT HUP INT TERM
+
+git -C "$REPO_ROOT" archive \
+  --format=tar \
+  --prefix="pantheon-local-tools-$VERSION/" \
+  "$ARCHIVE_REF" | gzip -n > "$TMP_SOURCE"
+mv "$TMP_SOURCE" "$SOURCE_PATH"
+trap - EXIT HUP INT TERM
+
+DEB_PATH=''
+if command -v dpkg-deb >/dev/null 2>&1; then
+  DEB_PATH=$(bash "$REPO_ROOT/packaging/debian/build-deb.sh" "$OUT_DIR")
+fi
+
+CHECKSUM_PATH="$OUT_DIR/SHA256SUMS"
+: > "$CHECKSUM_PATH"
+SOURCE_SHA=$(sha256_file "$SOURCE_PATH")
+printf '%s  %s\n' "$SOURCE_SHA" "$SOURCE_NAME" >> "$CHECKSUM_PATH"
+
+if [ -n "$DEB_PATH" ]; then
+  DEB_NAME=${DEB_PATH##*/}
+  DEB_SHA=$(sha256_file "$DEB_PATH")
+  printf '%s  %s\n' "$DEB_SHA" "$DEB_NAME" >> "$CHECKSUM_PATH"
+fi
+
+printf 'Release artifact set\n\n'
+printf 'Version:       %s\n' "$VERSION"
+printf 'Git ref:       %s\n' "$ARCHIVE_REF"
+printf 'Git SHA:       %s\n' "$HEAD_SHA"
+printf 'Source:        %s\n' "$SOURCE_PATH"
+printf 'Source SHA256: %s\n' "$SOURCE_SHA"
+if [ -n "$DEB_PATH" ]; then
+  printf 'Debian:        %s\n' "$DEB_PATH"
+else
+  printf 'Debian:        (not built; dpkg-deb unavailable)\n'
+fi
+printf 'Checksums:     %s\n' "$CHECKSUM_PATH"

--- a/tests/test-release-artifacts.sh
+++ b/tests/test-release-artifacts.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
+
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    fail 'SHA256 tool unavailable'
+  fi
+}
+
+VERSION=$(cat "$REPO_ROOT/VERSION")
+OUT_ONE="$TMP_ROOT/one"
+OUT_TWO="$TMP_ROOT/two"
+
+PANTHEON_LOCAL_RELEASE_ALLOW_UNTAGGED=1 \
+  bash "$REPO_ROOT/packaging/release/build-artifacts.sh" "$OUT_ONE" >/dev/null
+PANTHEON_LOCAL_RELEASE_ALLOW_UNTAGGED=1 \
+  bash "$REPO_ROOT/packaging/release/build-artifacts.sh" "$OUT_TWO" >/dev/null
+
+SOURCE_NAME="pantheon-local-tools-$VERSION.tar.gz"
+SOURCE_ONE="$OUT_ONE/$SOURCE_NAME"
+SOURCE_TWO="$OUT_TWO/$SOURCE_NAME"
+[ -f "$SOURCE_ONE" ] || fail 'release source archive was not created'
+[ -f "$SOURCE_TWO" ] || fail 'second release source archive was not created'
+[ -f "$OUT_ONE/SHA256SUMS" ] || fail 'SHA256SUMS was not created'
+
+SHA_ONE=$(sha256_file "$SOURCE_ONE")
+SHA_TWO=$(sha256_file "$SOURCE_TWO")
+assert_eq "$SHA_ONE" "$SHA_TWO"
+grep -F "$SHA_ONE  $SOURCE_NAME" "$OUT_ONE/SHA256SUMS" >/dev/null 2>&1 || \
+  fail 'source archive checksum is missing from SHA256SUMS'
+
+PREFIX="pantheon-local-tools-$VERSION"
+tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/VERSION" >/dev/null 2>&1 || fail 'VERSION missing from source archive'
+tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/bin/pantheon-local" >/dev/null 2>&1 || fail 'CLI missing from source archive'
+tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-core" >/dev/null 2>&1 || fail 'core module missing from source archive'
+if tar -tzf "$SOURCE_ONE" | grep -E '/\.git(/|$)|/dist(/|$)|/\.agents(/|$)' >/dev/null 2>&1; then
+  fail 'source archive contains repository-local/private build state'
+fi
+
+EXTRACT="$TMP_ROOT/extract"
+mkdir -p "$EXTRACT"
+tar -xzf "$SOURCE_ONE" -C "$EXTRACT"
+expected="pantheon-local $VERSION"
+assert_eq "$(bash "$EXTRACT/$PREFIX/bin/pantheon-local" --version)" "$expected"
+
+if command -v dpkg-deb >/dev/null 2>&1; then
+  DEB_NAME="pantheon-local-tools_${VERSION}_all.deb"
+  DEB_PATH="$OUT_ONE/$DEB_NAME"
+  [ -f "$DEB_PATH" ] || fail 'Debian release artifact was not created when dpkg-deb is available'
+  DEB_SHA=$(sha256_file "$DEB_PATH")
+  grep -F "$DEB_SHA  $DEB_NAME" "$OUT_ONE/SHA256SUMS" >/dev/null 2>&1 || \
+    fail 'Debian artifact checksum is missing from SHA256SUMS'
+fi
+
+printf 'release artifact tests passed\n'


### PR DESCRIPTION
## Summary

Turn the remaining v0.1 packaging/release sequence into a deterministic, reviewable workflow without publishing a release prematurely.

- add `packaging/release/build-artifacts.sh`
- require `vVERSION` to exist and point at current HEAD for normal release builds
- keep an explicit `PANTHEON_LOCAL_RELEASE_ALLOW_UNTAGGED=1` test-only boundary for pre-release CI
- build a deterministic `git archive | gzip -n` source payload with a stable top-level directory
- generate `SHA256SUMS`
- include the architecture-independent `.deb` automatically when `dpkg-deb` is available
- add cross-platform release-artifact tests, including deterministic source checksum, archive contents, version execution, and Debian checksum coverage where available
- add a maintainer release procedure covering version PR, tag identity, artifacts, GitHub Release, Homebrew tap publication, Debian validation, and recovery
- update the public README to reflect the already-implemented/tested Homebrew and Debian paths instead of describing them as merely planned

## Release boundary

This PR does **not** create `v0.1.0`, a GitHub Release, a public Homebrew tap formula, or a released `.deb`. Those remain gated on the real DDEV/WSL/clean-install release checks in #7.

## Validation intent

Required Ubuntu + macOS CI should prove syntax, ShellCheck, the existing integration suite, deterministic source packaging on both hosts, `.deb` inclusion on Ubuntu, and no regression to Homebrew/installer/provider tests.