### PR TITLE
Polish public pre-release presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable user-facing changes to Pantheon Local Tools are recorded here.
+
+The project follows Semantic Versioning for its public command/configuration contract. The repository-root `VERSION` file is canonical; tagged releases use the corresponding `vVERSION` Git tag.
+
+## 0.1.0 — Unreleased
+
+The first public release is still undergoing real-host/provider validation. Until `v0.1.0` is tagged, install from a clone only if you are comfortable using pre-release software.
+
+### Added
+
+- `pantheon-local config` with Git-compatible user configuration and XDG-aware storage.
+- User-defined Pantheon Tag-to-directory routing.
+- DDEV and Lando as provider adapters behind one CLI.
+- `pantheon-local multidev SITE.ENV` for cloning an existing Pantheon multidev into an isolated local checkout.
+- Transactional multidev creation using a temporary sibling checkout and no-overwrite finalization.
+- Explicit `--dry-run`, `--group`, `--provider`, and opt-in `--start` behavior.
+- `pantheon-local status` for local/read-only checkout, Git, provider, runtime URL, and data-provenance inspection.
+- Provider-authoritative runtime URL discovery without assuming `lndo.site` or `ddev.site`.
+- `pantheon-local pull ENV` with explicit Pantheon source selection and provider-owned authentication.
+- Database-only and files-only pull selection.
+- Independent database/files provenance recording after successful pulls.
+- Git-integrity guards that reject provenance recording if a data pull changes `HEAD` or tracked content.
+- `pantheon-local version` and `pantheon-local --version` backed by the canonical `VERSION` file.
+- Portable clone installer that does not edit shell startup files and refuses to overwrite unrelated commands.
+
+### Provider safety
+
+- Existing `.lando.yml` and `.ddev/config.yaml` remain provider/project authority.
+- Checkout isolation writes only minimal local name overrides.
+- Existing services, tooling, add-ons, custom hostnames, proxy routes, and Compose definitions are preserved.
+- Ambiguous provider detection fails instead of guessing.
+- Pantheon Local Tools does not collect or persist Pantheon machine tokens.
+- Lando/DDEV data-transfer implementations remain delegated to their supported provider interfaces.
+
+### Distribution prepared
+
+- Architecture-independent Debian package builder (`Architecture: all`).
+- Homebrew formula renderer using exact release URL/version/SHA256 inputs.
+- Real temporary-tap Homebrew install/test/uninstall coverage on macOS CI.
+- Deterministic `git archive | gzip -n` release source-artifact builder.
+- `SHA256SUMS` generation for release artifacts.
+- Maintainer release procedure covering tag identity, artifacts, GitHub Release, Homebrew tap publication, Debian packaging, and recovery.
+
+### Validation completed
+
+- Required shell syntax, ShellCheck, and integration tests on Ubuntu and macOS.
+- Isolated-home clone-installer tests on Ubuntu and macOS.
+- Real macOS + Lando multidev clone, isolated runtime start, Pantheon authentication, explicit database/files pull, provider-derived status, and Git-integrity validation.
+- Homebrew formula installation through an actual temporary tap on macOS CI.
+- Debian package build/extract/layout/version tests on Ubuntu CI.
+- Deterministic release source-artifact reproduction tests on Ubuntu and macOS.
+- Public repository audit for private site/account/organization/UUID/path values.
+
+### Still required before v0.1.0
+
+- Real DDEV + Pantheon multidev/start/pull/status validation (#17).
+- Real WSL2 fresh-clone/install/test validation (#18).
+- Real clean macOS fresh-clone/install/test validation (#18).
+- Final release-version commit/tag and immutable release artifact checksum verification.
+- Publication and clean-install verification of the real `zevarix/tap` Homebrew formula.
+- Released package-manager upgrade behavior.
+
+See issue #7 for the authoritative release-readiness tracker and `docs/real-integration-validation.md` for the real-environment procedures.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Pantheon Local Tools
 
+[![Validate](https://github.com/zevarix/pantheon-local-tools/actions/workflows/validate.yml/badge.svg?branch=main)](https://github.com/zevarix/pantheon-local-tools/actions/workflows/validate.yml)
+
+> **Pre-release:** `v0.1.0` is still completing real DDEV, WSL2, and clean-host validation. The command/configuration surface is documented, but no stable release has been tagged yet. See [`CHANGELOG.md`](CHANGELOG.md) and [release readiness](https://github.com/zevarix/pantheon-local-tools/issues/7).
+
 Provider-neutral local development helpers for Pantheon workflows, with DDEV and Lando as the first supported local providers.
 
 Pantheon Local Tools is being built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon Tags, local directory mappings, or local development stack.
@@ -222,6 +226,8 @@ pantheon-local --version
 
 The documented command/configuration and safety guarantees for the `0.1.x` line are defined in [`docs/compatibility.md`](docs/compatibility.md). Patch releases should preserve that contract; intentionally breaking pre-1.0 changes belong in a future minor release with release notes/migration guidance.
 
+See [`CHANGELOG.md`](CHANGELOG.md) for user-visible changes and current pre-release validation status.
+
 ## Installation and distribution
 
 ### Install from a clone
@@ -264,7 +270,7 @@ The package installs application files under `/usr/lib/pantheon-local-tools`, ex
 
 The clone installer remains supported as the portable fallback for macOS, Linux, WSL, contributors, and CI even after package-manager distribution is published.
 
-Maintainers should follow [`docs/releasing.md`](docs/releasing.md) for the tag, deterministic source archive, checksums, GitHub Release, Homebrew formula, and Debian artifact sequence.
+Maintainers should follow [`docs/releasing.md`](docs/releasing.md) for the tag, deterministic source archive, checksums, GitHub Release, Homebrew formula, and Debian artifact sequence. Real provider/host release gates are in [`docs/real-integration-validation.md`](docs/real-integration-validation.md).
 
 ## Development
 
@@ -288,8 +294,12 @@ CI runs syntax validation, ShellCheck, and the full shell integration suite on b
 
 ## Contributing
 
-Contributions are welcome. See `CONTRIBUTING.md`.
+Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 
-MIT license. See `LICENSE`.
+MIT license. See [`LICENSE`](LICENSE).
+
+## Independence
+
+Pantheon Local Tools is an independent open-source project. It is not an official Pantheon Systems project, and Pantheon remains authoritative for its platform, Terminus, and published product documentation.


### PR DESCRIPTION
## Summary

Improve the repository's public first impression without changing the runtime/API contract.

- add a native GitHub Actions validation badge
- make the current pre-release status explicit at the top of the README
- link the changelog and authoritative release-readiness tracker
- add `CHANGELOG.md` with the complete v0.1.0 feature/safety/distribution/validation summary and remaining real gates
- link the real-integration runbook from installation/release guidance
- make contributing/license links explicit
- add an independence statement so the project is not mistaken for an official Pantheon Systems product

## Scope

Documentation/presentation only. No CLI behavior, provider contract, packaging behavior, release version, or tag is changed.