### PR TITLE
Keep Homebrew smoke test on normal API mode

### DIFF
--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -13,7 +13,7 @@ BREW_CORE_WAS_TAPPED=0
 cleanup() {
   if command -v brew >/dev/null 2>&1; then
     if brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
-      HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+      HOMEBREW_NO_AUTO_UPDATE=1 \
         brew uninstall --force "$FORMULA_NAME" >/dev/null 2>&1 || true
     fi
     if brew tap | grep -Fx "$TAP" >/dev/null 2>&1; then
@@ -66,9 +66,9 @@ FORMULA="$TAP_ROOT/Formula/pantheon-local-tools.rb"
 bash "$REPO_ROOT/packaging/homebrew/render-formula.sh" "$VERSION" "$URL" "$SHA256" "$FORMULA" >/dev/null
 ruby -c "$FORMULA" >/dev/null
 
-HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+HOMEBREW_NO_AUTO_UPDATE=1 \
   brew install --build-from-source "$FULL_FORMULA" >/dev/null
-HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+HOMEBREW_NO_AUTO_UPDATE=1 \
   brew test "$FULL_FORMULA" >/dev/null
 
 PREFIX=$(brew --prefix "$FORMULA_NAME")


### PR DESCRIPTION
## Summary

Remove `HOMEBREW_NO_INSTALL_FROM_API=1` from the temporary-tap Homebrew smoke test.

The smoke test already installs a fully qualified third-party tap formula, so forcing Homebrew into local `homebrew/core` mode is unnecessary. Current Homebrew documents this flag for local core/cask development and warns that it uses large, slow local checkouts instead of the API.

Combined with #21, this keeps the smoke test focused on our formula while preserving host Homebrew state and avoiding unnecessary core downloads.

## Validation intent

Required Ubuntu + macOS CI should continue to prove the formula renders, installs from the temporary tap, runs `brew test`, reports the canonical version, exercises config, uninstalls, and cleans up without relying on local-core mode.