### PR TITLE
Isolate Homebrew config smoke from caller environment

### DIFF
--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -86,7 +86,13 @@ assert_eq "$("$FORMULA_CLI" --version)" "$expected"
 assert_eq "$("$FORMULA_CLI" version)" "$expected"
 
 TEST_HOME="$TMP_ROOT/home"
+CALLER_CONFIG="$TMP_ROOT/caller-config"
 mkdir -p "$TEST_HOME"
-assert_eq "$(HOME="$TEST_HOME" "$FORMULA_CLI" config path)" "$TEST_HOME/.config/pantheon-local-tools/config"
+assert_eq "$(PANTHEON_LOCAL_CONFIG="$CALLER_CONFIG" "$FORMULA_CLI" config path)" "$CALLER_CONFIG"
+DEFAULT_CONFIG_PATH=$(
+  unset PANTHEON_LOCAL_CONFIG XDG_CONFIG_HOME
+  HOME="$TEST_HOME" "$FORMULA_CLI" config path
+)
+assert_eq "$DEFAULT_CONFIG_PATH" "$TEST_HOME/.config/pantheon-local-tools/config"
 
 printf 'homebrew package tests passed\n'


### PR DESCRIPTION
## Summary

Fix the second real clean-macOS validation failure by isolating the Homebrew package smoke from inherited Pantheon Local Tools configuration variables.

A real workstation validation intentionally exported `PANTHEON_LOCAL_CONFIG` for the outer clean-install test. The Homebrew smoke then changed `HOME` and expected the default XDG config path without clearing that explicit override. The CLI correctly honored the inherited override; the test expectation was wrong.

This change:

- verifies the formula-installed CLI still honors an explicit `PANTHEON_LOCAL_CONFIG` value;
- clears both `PANTHEON_LOCAL_CONFIG` and `XDG_CONFIG_HOME` in a subshell before asserting the default `$HOME/.config/pantheon-local-tools/config` path;
- keeps the test Bash 3.2-compatible without depending on `env -u`;
- turns the real-host failure into deterministic CI coverage.

No CLI behavior or configuration precedence changes.