### PR TITLE
Reconcile post-release Homebrew packaging

### DIFF
--- a/docs/real-integration-validation.md
+++ b/docs/real-integration-validation.md
@@ -1,6 +1,6 @@
 # Real integration validation
 
-This runbook defines the remaining real-host/provider evidence required before the first public release. It complements deterministic CI; it does not replace it.
+This runbook defines real-host/provider validation procedures used for release qualification and ongoing compatibility evidence. It complements deterministic CI; it does not replace it.
 
 Keep real site names, account identities, machine tokens, UUIDs, organization Tags, private paths, and provider credentials out of public issues/commits. Record only sanitized outcomes in the public release tracker.
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,6 +1,6 @@
 # Homebrew packaging
 
-Pantheon Local Tools is designed to be published through a small external Homebrew tap after a tagged release exists.
+Pantheon Local Tools is published through a small external Homebrew tap using immutable tagged release artifacts.
 
 The intended tap repository is:
 
@@ -16,7 +16,7 @@ Formula/pantheon-local-tools.rb
 
 ## User installation
 
-After the first tagged release and tap publication, the preferred one-command installation is:
+For published releases, the preferred one-command installation is:
 
 ```bash
 brew install zevarix/tap/pantheon-local-tools
@@ -57,14 +57,14 @@ No provider configuration, user configuration, checkout state, or Pantheon crede
 bash packaging/homebrew/render-formula.sh VERSION URL SHA256 OUTPUT
 ```
 
-For a release, `VERSION` must equal the repository-root `VERSION` and the `vVERSION` Git tag. `URL` should be the immutable GitHub release source archive URL and `SHA256` must be calculated from that exact archive.
+For a release, `VERSION` must equal the repository-root `VERSION` and the `vVERSION` Git tag. `URL` should be the uploaded deterministic GitHub Release source asset URL and `SHA256` must match that exact published asset. Do not use GitHub's automatically generated tag archive for release formula metadata.
 
 Example shape after `v0.1.0` exists:
 
 ```bash
 VERSION=0.1.0
-URL="https://github.com/zevarix/pantheon-local-tools/archive/refs/tags/v${VERSION}.tar.gz"
-SHA256="<verified release archive sha256>"
+URL="https://github.com/zevarix/pantheon-local-tools/releases/download/v${VERSION}/pantheon-local-tools-${VERSION}.tar.gz"
+SHA256="<verified uploaded release source asset sha256>"
 bash packaging/homebrew/render-formula.sh \
   "$VERSION" "$URL" "$SHA256" \
   Formula/pantheon-local-tools.rb
@@ -86,7 +86,7 @@ The repository test suite performs a local Homebrew installation on macOS CI fro
 
 The test skips on hosts where Homebrew is unavailable, while the renderer still receives normal shell syntax and ShellCheck validation.
 
-Before publishing the real tap formula, validate the final release URL/checksum with current Homebrew tooling, including a build-from-source install, `brew test`, `brew audit --strict --new --online`, and `brew style`.
+For each published tap formula, validate the final release URL/checksum with current Homebrew tooling, including a build-from-source install, `brew test`, `brew audit --strict --new --online`, and `brew style`.
 
 ## Upgrade and uninstall
 

--- a/packaging/homebrew/render-formula.sh
+++ b/packaging/homebrew/render-formula.sh
@@ -25,7 +25,6 @@ escape_ruby_string() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
-VERSION_ESCAPED=$(escape_ruby_string "$VERSION")
 URL_ESCAPED=$(escape_ruby_string "$URL")
 SHA256_NORMALIZED=$(printf '%s' "$SHA256" | tr '[:upper:]' '[:lower:]')
 OUTPUT_DIR=${OUTPUT%/*}
@@ -37,11 +36,8 @@ class PantheonLocalTools < Formula
   desc "Provider-neutral local development helpers for Pantheon"
   homepage "https://github.com/zevarix/pantheon-local-tools"
   url "$URL_ESCAPED"
-  version "$VERSION_ESCAPED"
   sha256 "$SHA256_NORMALIZED"
   license "MIT"
-
-  uses_from_macos "git"
 
   def install
     libexec.install "bin", "libexec", "VERSION", "LICENSE", "README.md"

--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -66,6 +66,17 @@ FORMULA="$TAP_ROOT/Formula/pantheon-local-tools.rb"
 bash "$REPO_ROOT/packaging/homebrew/render-formula.sh" "$VERSION" "$URL" "$SHA256" "$FORMULA" >/dev/null
 ruby -c "$FORMULA" >/dev/null
 
+if grep -Eq '^[[:space:]]*version[[:space:]]' "$FORMULA"; then
+  fail 'Homebrew formula should infer its version from the release URL'
+fi
+
+if grep -Fq 'uses_from_macos "git"' "$FORMULA"; then
+  fail 'Homebrew formula should not declare git as a dependency'
+fi
+
+HOMEBREW_NO_AUTO_UPDATE=1 \
+  brew style "$FULL_FORMULA" >/dev/null
+
 HOMEBREW_NO_AUTO_UPDATE=1 \
   brew install --build-from-source "$FULL_FORMULA" >/dev/null
 HOMEBREW_NO_AUTO_UPDATE=1 \


### PR DESCRIPTION
## Summary

Reconcile the Homebrew renderer and release-era documentation after the public `v0.1.0` release.

This PR:

- removes the redundant explicit Homebrew `version` line from rendered formulas;
- removes the unnecessary `uses_from_macos "git"` declaration;
- adds regression assertions and `brew style` coverage to the Homebrew package smoke test;
- updates the Homebrew release example to use the uploaded deterministic GitHub Release source asset and verified checksum; and
- refreshes stale pre-first-release wording in the real integration validation runbook.

The published `v0.1.0` tag and release artifacts remain unchanged.

Closes #27.
Closes #28.