### PR TITLE
Document public merge identity safeguards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ Never add machine tokens or other credentials to tests, fixtures, documentation 
 
 The repository uses squash merging so each reviewed pull request becomes one canonical integration commit.
 
+For public repository work, maintainers should use a GitHub noreply address for repository-local Git author and committer identity and keep GitHub email privacy protections enabled. Before treating a merge procedure as privacy-safe, verify both author and committer metadata on the resulting public commit do not expose a private email address.
+
 ## Safety expectations
 
 This project interacts with developer environments and Pantheon sites. Changes must fail safely.


### PR DESCRIPTION
## Summary

Document the public-repository merge identity safeguards established after the v0.1.0 release.

This PR also serves as the controlled verification for #33 after enabling GitHub account email privacy protections. The branch commit was created locally with a GitHub noreply address for both author and committer metadata.

After required CI passes, this PR will be merged using the repository's normal squash-merge path. The resulting public commit will then be inspected for both author and committer identity before #33 is considered complete.

Closes #33.