### PR TITLE
Add signed APT repository tooling

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes shellcheck
+          sudo apt-get install --yes shellcheck dpkg-dev gnupg
 
       - name: Install ShellCheck on macOS
         if: runner.os == 'macOS'

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -71,8 +71,92 @@ Package removal does not own that file and therefore must not delete it. Checkou
 
 ## Signed APT repository
 
-A downloadable `.deb` and a hosted APT repository are separate distribution layers.
+The hosted APT repository is a separate distribution layer from the downloadable `.deb`.
 
-The initial package can be attached directly to a GitHub Release. A later signed APT repository can add normal `apt update` / `apt install pantheon-local-tools` upgrade discovery after repository hosting, signing/keyring policy, metadata publication, and rotation/recovery procedures are established.
+Repository tooling uses a conventional Debian archive layout:
 
-The hosted APT repository is intentionally not required to ship the first `.deb`.
+```text
+pool/main/p/pantheon-local-tools/
+  pantheon-local-tools_<VERSION>_all.deb
+
+dists/stable/
+  Release
+  InRelease
+  Release.gpg
+  main/binary-all/
+    Packages
+    Packages.gz
+
+pantheon-local-tools-archive-keyring.gpg
+```
+
+`Architecture: all` has its own package index. The `Release` metadata declares `Architectures: all`, `Components: main`, `Suite: stable`, and `Codename: stable`.
+
+### Build repository metadata
+
+Build the `.deb` first, then create a fresh repository tree:
+
+```bash
+PACKAGE=$(bash packaging/debian/build-deb.sh)
+SOURCE_DATE_EPOCH=<release-epoch> \
+  bash packaging/debian/build-apt-repository.sh \
+    dist/apt-repository \
+    "$PACKAGE"
+```
+
+The repository builder:
+
+- accepts one or more `pantheon-local-tools` packages;
+- requires every package to use `Architecture: all`;
+- rejects duplicate package versions;
+- requires at least one input package whose version matches the checkout's root `VERSION`;
+- writes package files under `pool/`;
+- generates `Packages` plus deterministic `Packages.gz`;
+- covers both indexes with SHA-256 and SHA-512 entries in `Release`; and
+- produces reproducible repository metadata when `SOURCE_DATE_EPOCH` is fixed.
+
+The output path must not already exist. This prevents stale indexes or packages from being silently mixed into a new publication tree.
+
+### Sign repository metadata
+
+Signing is intentionally separate from repository generation:
+
+```bash
+bash packaging/debian/sign-apt-repository.sh \
+  dist/apt-repository \
+  FULL_SIGNING_KEY_FINGERPRINT
+```
+
+The signer requires the corresponding secret key to already exist in the caller's GPG keyring. It creates:
+
+- `dists/stable/InRelease`;
+- `dists/stable/Release.gpg`; and
+- `pantheon-local-tools-archive-keyring.gpg`.
+
+It immediately verifies both signatures using the exported public keyring.
+
+Do **not** store a production private signing key, passphrase, or exported secret-key material in this repository, release assets, generated repository content, workflow logs, or public issue comments.
+
+CI validates the signing path with an ephemeral throwaway key. Production key creation, secure backup, rotation/recovery policy, and publication credentials are separate operational concerns.
+
+### Client trust
+
+The final public repository will use a dedicated keyring under `/etc/apt/keyrings` and APT's `Signed-By` mechanism. It must not use deprecated `apt-key` or add the archive key to global APT trust.
+
+The intended deb822 source shape is:
+
+```text
+Types: deb
+URIs: <APT_REPOSITORY_URL>
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
+```
+
+The public repository URL and production key installation commands are documented only after the repository is actually published and verified.
+
+### Publication boundary
+
+Repository hosting and production signing are tracked separately from deterministic packaging. The current publication plan is an Actions-built static archive on the project's GitHub Pages site, with historical released `.deb` files retained so future upgrade and downgrade/reinstall tests remain possible.
+
+The first real package upgrade remains deferred until a second published Debian package exists.

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -111,7 +111,7 @@ The repository builder:
 - rejects duplicate package versions;
 - requires at least one input package whose version matches the checkout's root `VERSION`;
 - writes package files under `pool/`;
-- generates `Packages` plus deterministic `Packages.gz`;
+- indexes every supplied released version with `dpkg-scanpackages --multiversion` and generates `Packages` plus deterministic `Packages.gz`;
 - covers both indexes with SHA-256 and SHA-512 entries in `Release`; and
 - produces reproducible repository metadata when `SOURCE_DATE_EPOCH` is fixed.
 

--- a/packaging/debian/build-apt-repository.sh
+++ b/packaging/debian/build-apt-repository.sh
@@ -105,7 +105,7 @@ PACKAGES_GZ="$PACKAGES.gz"
 
 (
   cd "$STAGE"
-  dpkg-scanpackages --arch all "$POOL_REL"
+  dpkg-scanpackages --arch all --multiversion "$POOL_REL"
 ) > "$PACKAGES"
 
 gzip -n -9 -c "$PACKAGES" > "$PACKAGES_GZ"

--- a/packaging/debian/build-apt-repository.sh
+++ b/packaging/debian/build-apt-repository.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME='pantheon-local-tools APT repository builder'
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+[ "$#" -ge 2 ] || die 'usage: build-apt-repository.sh OUTPUT_DIR PACKAGE [PACKAGE ...]'
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
+VERSION_FILE="$REPO_ROOT/VERSION"
+OUTPUT_DIR=$1
+shift
+
+require_command awk
+require_command basename
+require_command date
+require_command dirname
+require_command dpkg-deb
+require_command dpkg-scanpackages
+require_command grep
+require_command gzip
+require_command install
+require_command mktemp
+require_command mv
+require_command sha256sum
+require_command sha512sum
+require_command tr
+require_command wc
+
+[ -f "$VERSION_FILE" ] || die "VERSION file not found: $VERSION_FILE"
+CURRENT_VERSION=$(cat "$VERSION_FILE")
+[ -n "$CURRENT_VERSION" ] || die 'VERSION cannot be empty'
+case "$CURRENT_VERSION" in
+  *$'\n'*|*$'\r'*) die 'VERSION must be a single line' ;;
+esac
+
+case "$OUTPUT_DIR" in
+  /*) ;;
+  *) OUTPUT_DIR="$PWD/$OUTPUT_DIR" ;;
+esac
+
+[ ! -e "$OUTPUT_DIR" ] || die "output path already exists: $OUTPUT_DIR"
+OUTPUT_PARENT=$(dirname "$OUTPUT_DIR")
+mkdir -p "$OUTPUT_PARENT"
+OUTPUT_PARENT=$(cd "$OUTPUT_PARENT" && pwd)
+OUTPUT_DIR="$OUTPUT_PARENT/$(basename "$OUTPUT_DIR")"
+
+STAGE=$(mktemp -d "$OUTPUT_PARENT/.pantheon-local-tools-apt.XXXXXX")
+chmod 0755 "$STAGE"
+VERSIONS_FILE="$STAGE/.versions"
+trap 'rm -rf "$STAGE"' EXIT HUP INT TERM
+: > "$VERSIONS_FILE"
+
+POOL_REL='pool/main/p/pantheon-local-tools'
+INDEX_REL='dists/stable/main/binary-all'
+install -d "$STAGE/$POOL_REL" "$STAGE/$INDEX_REL"
+
+CURRENT_VERSION_PRESENT=0
+
+for package in "$@"; do
+  [ -f "$package" ] || die "package not found: $package"
+
+  package_name=$(dpkg-deb -f "$package" Package)
+  package_version=$(dpkg-deb -f "$package" Version)
+  package_architecture=$(dpkg-deb -f "$package" Architecture)
+
+  [ "$package_name" = 'pantheon-local-tools' ] ||
+    die "unexpected package name in $package: $package_name"
+  [ "$package_architecture" = 'all' ] ||
+    die "unexpected package architecture in $package: $package_architecture"
+  [ -n "$package_version" ] || die "package version is empty: $package"
+
+  case "$package_version" in
+    *$'\n'*|*$'\r'*) die "package version must be a single line: $package" ;;
+  esac
+
+  if grep -Fx "$package_version" "$VERSIONS_FILE" >/dev/null 2>&1; then
+    die "duplicate package version: $package_version"
+  fi
+  printf '%s\n' "$package_version" >> "$VERSIONS_FILE"
+
+  if [ "$package_version" = "$CURRENT_VERSION" ]; then
+    CURRENT_VERSION_PRESENT=1
+  fi
+
+  destination="$STAGE/$POOL_REL/pantheon-local-tools_${package_version}_all.deb"
+  install -m 0644 "$package" "$destination"
+done
+
+[ "$CURRENT_VERSION_PRESENT" -eq 1 ] ||
+  die "no input package matches repository VERSION $CURRENT_VERSION"
+
+rm -f "$VERSIONS_FILE"
+
+PACKAGES="$STAGE/$INDEX_REL/Packages"
+PACKAGES_GZ="$PACKAGES.gz"
+
+(
+  cd "$STAGE"
+  dpkg-scanpackages --arch all "$POOL_REL"
+) > "$PACKAGES"
+
+gzip -n -9 -c "$PACKAGES" > "$PACKAGES_GZ"
+
+if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+  printf '%s\n' "$SOURCE_DATE_EPOCH" | grep -Eq '^[0-9]+$' ||
+    die 'SOURCE_DATE_EPOCH must be an integer'
+  RELEASE_DATE=$(date -u -R -d "@$SOURCE_DATE_EPOCH")
+else
+  RELEASE_DATE=$(date -u -R)
+fi
+
+file_size() {
+  wc -c < "$1" | tr -d '[:space:]'
+}
+
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+sha512_file() {
+  sha512sum "$1" | awk '{print $1}'
+}
+
+RELEASE="$STAGE/dists/stable/Release"
+
+cat > "$RELEASE" <<EOF_RELEASE
+Origin: Pantheon Local Tools
+Label: Pantheon Local Tools
+Suite: stable
+Codename: stable
+Date: $RELEASE_DATE
+Architectures: all
+Components: main
+Description: Pantheon Local Tools APT repository
+SHA256:
+ $(sha256_file "$PACKAGES") $(file_size "$PACKAGES") main/binary-all/Packages
+ $(sha256_file "$PACKAGES_GZ") $(file_size "$PACKAGES_GZ") main/binary-all/Packages.gz
+SHA512:
+ $(sha512_file "$PACKAGES") $(file_size "$PACKAGES") main/binary-all/Packages
+ $(sha512_file "$PACKAGES_GZ") $(file_size "$PACKAGES_GZ") main/binary-all/Packages.gz
+EOF_RELEASE
+
+mv "$STAGE" "$OUTPUT_DIR"
+trap - EXIT HUP INT TERM
+
+printf '%s\n' "$OUTPUT_DIR"

--- a/packaging/debian/sign-apt-repository.sh
+++ b/packaging/debian/sign-apt-repository.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME='pantheon-local-tools APT repository signer'
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+[ "$#" -eq 2 ] ||
+  die 'usage: sign-apt-repository.sh REPOSITORY_DIR SIGNING_KEY_FINGERPRINT'
+
+REPOSITORY_DIR=$1
+SIGNING_KEY=$2
+
+require_command gpg
+require_command gpgv
+require_command grep
+
+[ -d "$REPOSITORY_DIR" ] ||
+  die "repository directory not found: $REPOSITORY_DIR"
+
+REPOSITORY_DIR=$(cd "$REPOSITORY_DIR" && pwd)
+RELEASE="$REPOSITORY_DIR/dists/stable/Release"
+INRELEASE="$REPOSITORY_DIR/dists/stable/InRelease"
+RELEASE_GPG="$REPOSITORY_DIR/dists/stable/Release.gpg"
+KEYRING="$REPOSITORY_DIR/pantheon-local-tools-archive-keyring.gpg"
+
+[ -f "$RELEASE" ] || die "Release file not found: $RELEASE"
+
+printf '%s\n' "$SIGNING_KEY" |
+  grep -Eq '^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$' ||
+  die 'signing key must be a full 40- or 64-hex fingerprint'
+
+gpg --batch --list-secret-keys "$SIGNING_KEY" >/dev/null 2>&1 ||
+  die 'signing secret key is not available'
+
+rm -f "$INRELEASE" "$RELEASE_GPG" "$KEYRING"
+
+gpg --batch --yes --local-user "$SIGNING_KEY" --armor --clearsign \
+  --output "$INRELEASE" "$RELEASE"
+
+gpg --batch --yes --local-user "$SIGNING_KEY" --armor --detach-sign \
+  --output "$RELEASE_GPG" "$RELEASE"
+
+gpg --batch --yes --export "$SIGNING_KEY" > "$KEYRING"
+[ -s "$KEYRING" ] || die 'public archive key export is empty'
+
+chmod 0644 "$INRELEASE" "$RELEASE_GPG" "$KEYRING"
+
+gpgv --keyring "$KEYRING" "$INRELEASE" >/dev/null 2>&1 ||
+  die 'InRelease verification failed'
+
+gpgv --keyring "$KEYRING" "$RELEASE_GPG" "$RELEASE" >/dev/null 2>&1 ||
+  die 'Release.gpg verification failed'
+
+printf '%s\n' "$REPOSITORY_DIR"

--- a/tests/test-apt-repository.sh
+++ b/tests/test-apt-repository.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+chmod 0755 "$TMP_ROOT"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "expected [$2], got [$1]"
+}
+
+for command_name in \
+  apt-cache apt-get dpkg-deb dpkg-scanpackages gpg gpgv sha256sum sha512sum
+do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'apt repository tests skipped (%s unavailable)\n' "$command_name"
+    exit 0
+  fi
+done
+
+VERSION=$(cat "$REPO_ROOT/VERSION")
+PACKAGE=$(bash "$REPO_ROOT/packaging/debian/build-deb.sh" "$TMP_ROOT/package")
+
+REPOSITORY_ONE="$TMP_ROOT/repository-one"
+REPOSITORY_TWO="$TMP_ROOT/repository-two"
+SOURCE_DATE_EPOCH=1787875200
+export SOURCE_DATE_EPOCH
+
+bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+  "$REPOSITORY_ONE" "$PACKAGE" >/dev/null
+
+bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+  "$REPOSITORY_TWO" "$PACKAGE" >/dev/null
+
+diff -ru "$REPOSITORY_ONE" "$REPOSITORY_TWO" >/dev/null ||
+  fail 'APT repository metadata is not reproducible with fixed SOURCE_DATE_EPOCH'
+
+PACKAGES="$REPOSITORY_ONE/dists/stable/main/binary-all/Packages"
+PACKAGES_GZ="$PACKAGES.gz"
+RELEASE="$REPOSITORY_ONE/dists/stable/Release"
+POOL_PACKAGE="$REPOSITORY_ONE/pool/main/p/pantheon-local-tools/pantheon-local-tools_${VERSION}_all.deb"
+
+[ -f "$POOL_PACKAGE" ] || fail 'APT pool package is missing'
+[ -f "$PACKAGES" ] || fail 'APT Packages index is missing'
+[ -f "$PACKAGES_GZ" ] || fail 'APT Packages.gz index is missing'
+[ -f "$RELEASE" ] || fail 'APT Release file is missing'
+
+assert_eq "$(dpkg-deb -f "$POOL_PACKAGE" Package)" 'pantheon-local-tools'
+assert_eq "$(dpkg-deb -f "$POOL_PACKAGE" Version)" "$VERSION"
+assert_eq "$(dpkg-deb -f "$POOL_PACKAGE" Architecture)" 'all'
+
+grep -Fx 'Origin: Pantheon Local Tools' "$RELEASE" >/dev/null ||
+  fail 'Release Origin is missing'
+grep -Fx 'Suite: stable' "$RELEASE" >/dev/null ||
+  fail 'Release Suite is missing'
+grep -Fx 'Codename: stable' "$RELEASE" >/dev/null ||
+  fail 'Release Codename is missing'
+grep -Fx 'Architectures: all' "$RELEASE" >/dev/null ||
+  fail 'Release Architectures is missing'
+grep -Fx 'Components: main' "$RELEASE" >/dev/null ||
+  fail 'Release Components is missing'
+grep -F ' main/binary-all/Packages' "$RELEASE" >/dev/null ||
+  fail 'Release does not cover Packages'
+grep -F ' main/binary-all/Packages.gz' "$RELEASE" >/dev/null ||
+  fail 'Release does not cover Packages.gz'
+
+grep -Fx 'Package: pantheon-local-tools' "$PACKAGES" >/dev/null ||
+  fail 'Packages index is missing package name'
+grep -Fx "Version: $VERSION" "$PACKAGES" >/dev/null ||
+  fail 'Packages index is missing current version'
+grep -Fx 'Architecture: all' "$PACKAGES" >/dev/null ||
+  fail 'Packages index is missing architecture'
+grep -Fx "Filename: pool/main/p/pantheon-local-tools/pantheon-local-tools_${VERSION}_all.deb" \
+  "$PACKAGES" >/dev/null ||
+  fail 'Packages index has the wrong package path'
+
+PACKAGE_SHA=$(sha256sum "$PACKAGE" | awk '{print $1}')
+INDEX_SHA=$(awk '/^SHA256:/ {print $2; exit}' "$PACKAGES")
+assert_eq "$INDEX_SHA" "$PACKAGE_SHA"
+
+GNUPGHOME="$TMP_ROOT/gnupg"
+export GNUPGHOME
+mkdir -m 0700 "$GNUPGHOME"
+
+gpg --batch --passphrase '' --quick-generate-key \
+  'Pantheon Local Tools CI <ci@example.invalid>' \
+  rsa2048 sign 1d >/dev/null 2>&1
+
+SIGNING_KEY=$(
+  gpg --batch --with-colons --list-secret-keys |
+    awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+)
+
+[ -n "$SIGNING_KEY" ] || fail 'ephemeral signing key fingerprint is missing'
+
+bash "$REPO_ROOT/packaging/debian/sign-apt-repository.sh" \
+  "$REPOSITORY_ONE" "$SIGNING_KEY" >/dev/null
+
+INRELEASE="$REPOSITORY_ONE/dists/stable/InRelease"
+RELEASE_GPG="$REPOSITORY_ONE/dists/stable/Release.gpg"
+KEYRING="$REPOSITORY_ONE/pantheon-local-tools-archive-keyring.gpg"
+
+[ -f "$INRELEASE" ] || fail 'InRelease is missing'
+[ -f "$RELEASE_GPG" ] || fail 'Release.gpg is missing'
+[ -s "$KEYRING" ] || fail 'public archive keyring is missing'
+
+gpgv --keyring "$KEYRING" "$INRELEASE" >/dev/null 2>&1 ||
+  fail 'InRelease does not verify with the exported keyring'
+
+gpgv --keyring "$KEYRING" "$RELEASE_GPG" "$RELEASE" >/dev/null 2>&1 ||
+  fail 'Release.gpg does not verify with the exported keyring'
+
+APT_ROOT="$TMP_ROOT/apt"
+mkdir -p "$APT_ROOT/lists/partial" "$APT_ROOT/cache/archives/partial"
+touch "$APT_ROOT/status"
+
+SOURCE_LIST="$TMP_ROOT/sources.list"
+printf 'deb [signed-by=%s] file:%s stable main\n' \
+  "$KEYRING" "$REPOSITORY_ONE" > "$SOURCE_LIST"
+
+APT_OPTIONS=(
+  -o "Dir::Etc::sourcelist=$SOURCE_LIST"
+  -o "Dir::Etc::sourceparts=-"
+  -o "Dir::State::lists=$APT_ROOT/lists"
+  -o "Dir::State::status=$APT_ROOT/status"
+  -o "Dir::Cache=$APT_ROOT/cache"
+  -o "Dir::Cache::archives=$APT_ROOT/cache/archives"
+  -o "Dir::Cache::pkgcache=$APT_ROOT/cache/pkgcache.bin"
+  -o "Dir::Cache::srcpkgcache=$APT_ROOT/cache/srcpkgcache.bin"
+  -o 'APT::Get::List-Cleanup=0'
+)
+
+apt-get "${APT_OPTIONS[@]}" update >/dev/null
+
+CANDIDATE=$(
+  apt-cache "${APT_OPTIONS[@]}" policy pantheon-local-tools |
+    awk '/Candidate:/ && !found { print $2; found = 1 }'
+)
+assert_eq "$CANDIDATE" "$VERSION"
+
+DOWNLOAD_ROOT="$TMP_ROOT/download"
+mkdir -p "$DOWNLOAD_ROOT"
+
+(
+  cd "$DOWNLOAD_ROOT"
+  apt-get "${APT_OPTIONS[@]}" download pantheon-local-tools >/dev/null 2>&1
+)
+
+DOWNLOADED_PACKAGE="$DOWNLOAD_ROOT/pantheon-local-tools_${VERSION}_all.deb"
+[ -f "$DOWNLOADED_PACKAGE" ] || fail 'APT did not download the expected package'
+
+cmp "$DOWNLOADED_PACKAGE" "$POOL_PACKAGE" ||
+  fail 'APT-downloaded package differs from repository package'
+
+cmp "$DOWNLOADED_PACKAGE" "$PACKAGE" ||
+  fail 'APT-downloaded package differs from source package'
+
+printf 'apt repository tests passed\n'

--- a/tests/test-apt-repository.sh
+++ b/tests/test-apt-repository.sh
@@ -27,16 +27,45 @@ done
 VERSION=$(cat "$REPO_ROOT/VERSION")
 PACKAGE=$(bash "$REPO_ROOT/packaging/debian/build-deb.sh" "$TMP_ROOT/package")
 
+OLDER_VERSION='0.0.0-test1'
+OLDER_STAGE="$TMP_ROOT/older-stage"
+OLDER_PACKAGE="$TMP_ROOT/pantheon-local-tools_${OLDER_VERSION}_all.deb"
+
+mkdir -p "$OLDER_STAGE"
+dpkg-deb -R "$PACKAGE" "$OLDER_STAGE"
+
+python3 - "$OLDER_STAGE/DEBIAN/control" "$OLDER_VERSION" <<'PY_CONTROL'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+version = sys.argv[2]
+text = path.read_text()
+
+lines = text.splitlines()
+for index, line in enumerate(lines):
+    if line.startswith("Version: "):
+        lines[index] = f"Version: {version}"
+        break
+else:
+    raise SystemExit("STOP: extracted package control has no Version field")
+
+path.write_text("\n".join(lines) + "\n")
+PY_CONTROL
+
+dpkg-deb --root-owner-group --build "$OLDER_STAGE" "$OLDER_PACKAGE" >/dev/null
+assert_eq "$(dpkg-deb -f "$OLDER_PACKAGE" Version)" "$OLDER_VERSION"
+
 REPOSITORY_ONE="$TMP_ROOT/repository-one"
 REPOSITORY_TWO="$TMP_ROOT/repository-two"
 SOURCE_DATE_EPOCH=1787875200
 export SOURCE_DATE_EPOCH
 
 bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
-  "$REPOSITORY_ONE" "$PACKAGE" >/dev/null
+  "$REPOSITORY_ONE" "$OLDER_PACKAGE" "$PACKAGE" >/dev/null
 
 bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
-  "$REPOSITORY_TWO" "$PACKAGE" >/dev/null
+  "$REPOSITORY_TWO" "$OLDER_PACKAGE" "$PACKAGE" >/dev/null
 
 diff -ru "$REPOSITORY_ONE" "$REPOSITORY_TWO" >/dev/null ||
   fail 'APT repository metadata is not reproducible with fixed SOURCE_DATE_EPOCH'
@@ -45,8 +74,10 @@ PACKAGES="$REPOSITORY_ONE/dists/stable/main/binary-all/Packages"
 PACKAGES_GZ="$PACKAGES.gz"
 RELEASE="$REPOSITORY_ONE/dists/stable/Release"
 POOL_PACKAGE="$REPOSITORY_ONE/pool/main/p/pantheon-local-tools/pantheon-local-tools_${VERSION}_all.deb"
+OLDER_POOL_PACKAGE="$REPOSITORY_ONE/pool/main/p/pantheon-local-tools/pantheon-local-tools_${OLDER_VERSION}_all.deb"
 
-[ -f "$POOL_PACKAGE" ] || fail 'APT pool package is missing'
+[ -f "$POOL_PACKAGE" ] || fail 'APT current pool package is missing'
+[ -f "$OLDER_POOL_PACKAGE" ] || fail 'APT older pool package is missing'
 [ -f "$PACKAGES" ] || fail 'APT Packages index is missing'
 [ -f "$PACKAGES_GZ" ] || fail 'APT Packages.gz index is missing'
 [ -f "$RELEASE" ] || fail 'APT Release file is missing'
@@ -70,19 +101,51 @@ grep -F ' main/binary-all/Packages' "$RELEASE" >/dev/null ||
 grep -F ' main/binary-all/Packages.gz' "$RELEASE" >/dev/null ||
   fail 'Release does not cover Packages.gz'
 
-grep -Fx 'Package: pantheon-local-tools' "$PACKAGES" >/dev/null ||
-  fail 'Packages index is missing package name'
+PACKAGE_STANZAS=$(grep -c '^Package: pantheon-local-tools$' "$PACKAGES")
+assert_eq "$PACKAGE_STANZAS" '2'
+
 grep -Fx "Version: $VERSION" "$PACKAGES" >/dev/null ||
   fail 'Packages index is missing current version'
-grep -Fx 'Architecture: all' "$PACKAGES" >/dev/null ||
-  fail 'Packages index is missing architecture'
+grep -Fx "Version: $OLDER_VERSION" "$PACKAGES" >/dev/null ||
+  fail 'Packages index is missing older version'
+
+ARCHITECTURE_STANZAS=$(grep -c '^Architecture: all$' "$PACKAGES")
+assert_eq "$ARCHITECTURE_STANZAS" '2'
+
 grep -Fx "Filename: pool/main/p/pantheon-local-tools/pantheon-local-tools_${VERSION}_all.deb" \
   "$PACKAGES" >/dev/null ||
-  fail 'Packages index has the wrong package path'
+  fail 'Packages index is missing current package path'
+
+grep -Fx "Filename: pool/main/p/pantheon-local-tools/pantheon-local-tools_${OLDER_VERSION}_all.deb" \
+  "$PACKAGES" >/dev/null ||
+  fail 'Packages index is missing older package path'
 
 PACKAGE_SHA=$(sha256sum "$PACKAGE" | awk '{print $1}')
-INDEX_SHA=$(awk '/^SHA256:/ {print $2; exit}' "$PACKAGES")
+INDEX_SHA=$(
+  awk -v version="$VERSION" '
+    /^Version: / {
+      current = ($2 == version)
+    }
+    current && /^SHA256: / {
+      print $2
+    }
+  ' "$PACKAGES"
+)
 assert_eq "$INDEX_SHA" "$PACKAGE_SHA"
+
+if bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+  "$TMP_ROOT/duplicate-version-repository" "$PACKAGE" "$PACKAGE" \
+  >/dev/null 2>&1
+then
+  fail 'repository builder accepted duplicate package versions'
+fi
+
+if bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+  "$TMP_ROOT/missing-current-repository" "$OLDER_PACKAGE" \
+  >/dev/null 2>&1
+then
+  fail 'repository builder accepted a repository without the current version'
+fi
 
 GNUPGHOME="$TMP_ROOT/gnupg"
 export GNUPGHOME


### PR DESCRIPTION
## Summary

Add the deterministic repository-generation and signing-tooling layer for the signed APT distribution tracked in #35 and parent #9.

This PR:

- builds a conventional `stable/main` APT repository for `Architecture: all` packages;
- validates package name/architecture/version uniqueness and requires the checkout's current version;
- generates reproducible `Packages`, deterministic `Packages.gz`, and SHA-256/SHA-512-covered `Release` metadata when `SOURCE_DATE_EPOCH` is fixed;
- keeps signing separate from repository generation and requires an externally supplied full GPG fingerprint;
- emits and immediately verifies `InRelease`, `Release.gpg`, and the public archive keyring;
- tests the complete path with an ephemeral CI signing key and an isolated APT client that authenticates the repository, discovers the expected candidate, and downloads the exact package bytes;
- documents the production-secret boundary and `/etc/apt/keyrings` + `Signed-By` client-trust model without deprecated `apt-key` usage.

The production signing key and public GitHub Pages publication remain deliberately outside this PR and are tracked in #36.

Closes #35.