### PR TITLE
Add signed APT publication pipeline

### DIFF
--- a/.github/workflows/publish-apt-repository.yml
+++ b/.github/workflows/publish-apt-repository.yml
@@ -1,0 +1,219 @@
+name: Publish APT Repository
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish-apt-repository.yml'
+      - 'packaging/debian/**'
+      - 'tests/test-apt-repository.sh'
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable release version to publish, for example 0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apt-repository-publication
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.event_name != 'release' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Debian and signing tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes dpkg-dev gnupg
+
+      - name: Resolve target version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              version=$(cat VERSION)
+              ;;
+            release)
+              version='${{ github.event.release.tag_name }}'
+              version=${version#v}
+              ;;
+            workflow_dispatch)
+              version='${{ inputs.version }}'
+              version=${version#v}
+              ;;
+            *)
+              printf 'unsupported event: %s\n' '${{ github.event_name }}' >&2
+              exit 1
+              ;;
+          esac
+
+          dpkg --validate-version "$version"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Assemble verified repository from stable releases
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash packaging/debian/build-published-apt-repository.sh \
+            "$RUNNER_TEMP/apt-repository" \
+            "$GITHUB_REPOSITORY" \
+            '${{ steps.version.outputs.version }}'
+
+      - name: Sign dry-run repository with ephemeral key
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          mkdir -m 0700 "$GNUPGHOME"
+          passphrase='apt-publication-pr-test'
+
+          gpg --batch --pinentry-mode loopback \
+            --passphrase "$passphrase" \
+            --quick-generate-key \
+            'Pantheon Local Tools PR <ci@example.invalid>' \
+            rsa2048 sign 1d >/dev/null 2>&1
+
+          fingerprint=$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+          )
+
+          [ -n "$fingerprint" ]
+
+          PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE="$passphrase" \
+            bash packaging/debian/sign-apt-repository.sh \
+              "$RUNNER_TEMP/apt-repository" \
+              "$fingerprint"
+
+      - name: Import production archive signing key and sign repository
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          APT_SIGNING_PRIVATE_KEY: ${{ secrets.APT_SIGNING_PRIVATE_KEY }}
+          APT_SIGNING_PASSPHRASE: ${{ secrets.APT_SIGNING_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+
+          [ -n "$APT_SIGNING_PRIVATE_KEY" ] || {
+            echo 'APT_SIGNING_PRIVATE_KEY is not configured' >&2
+            exit 1
+          }
+
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          mkdir -m 0700 "$GNUPGHOME"
+          printf '%s\n' "$APT_SIGNING_PRIVATE_KEY" | gpg --batch --import >/dev/null 2>&1
+
+          fingerprint=$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+          )
+
+          [ -n "$fingerprint" ] || {
+            echo 'production signing key fingerprint could not be resolved' >&2
+            exit 1
+          }
+
+          PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE="$APT_SIGNING_PASSPHRASE" \
+            bash packaging/debian/sign-apt-repository.sh \
+              "$RUNNER_TEMP/apt-repository" \
+              "$fingerprint"
+
+      - name: Validate signed repository with isolated APT client
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repository="$RUNNER_TEMP/apt-repository"
+          keyring="$repository/pantheon-local-tools-archive-keyring.gpg"
+          version='${{ steps.version.outputs.version }}'
+
+          gpgv --keyring "$keyring" \
+            "$repository/dists/stable/InRelease" >/dev/null
+
+          apt_root="$RUNNER_TEMP/apt-client"
+          mkdir -p \
+            "$apt_root/lists/partial" \
+            "$apt_root/cache/archives/partial"
+          touch "$apt_root/status"
+
+          source_list="$RUNNER_TEMP/pantheon-local-tools.list"
+          printf 'deb [signed-by=%s] file:%s stable main\n' \
+            "$keyring" "$repository" > "$source_list"
+
+          apt_options=(
+            -o "Dir::Etc::sourcelist=$source_list"
+            -o 'Dir::Etc::sourceparts=-'
+            -o "Dir::State::lists=$apt_root/lists"
+            -o "Dir::State::status=$apt_root/status"
+            -o "Dir::Cache=$apt_root/cache"
+            -o "Dir::Cache::archives=$apt_root/cache/archives"
+            -o "Dir::Cache::pkgcache=$apt_root/cache/pkgcache.bin"
+            -o "Dir::Cache::srcpkgcache=$apt_root/cache/srcpkgcache.bin"
+            -o 'APT::Get::List-Cleanup=0'
+          )
+
+          apt-get "${apt_options[@]}" update >/dev/null
+
+          candidate=$(
+            apt-cache "${apt_options[@]}" policy pantheon-local-tools |
+              awk '/Candidate:/ && !found { print $2; found = 1 }'
+          )
+
+          [ "$candidate" = "$version" ] || {
+            printf 'expected candidate %s, got %s\n' "$version" "$candidate" >&2
+            exit 1
+          }
+
+          download_root="$RUNNER_TEMP/apt-download"
+          mkdir -p "$download_root"
+          (
+            cd "$download_root"
+            apt-get "${apt_options[@]}" download \
+              "pantheon-local-tools=$version" >/dev/null 2>&1
+          )
+
+          downloaded="$download_root/pantheon-local-tools_${version}_all.deb"
+          published="$repository/pool/main/p/pantheon-local-tools/pantheon-local-tools_${version}_all.deb"
+
+          cmp "$downloaded" "$published"
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: ${{ runner.temp }}/apt-repository
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy APT repository to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/publish-apt-repository.yml
+++ b/.github/workflows/publish-apt-repository.yml
@@ -43,26 +43,33 @@ jobs:
       - name: Resolve target version
         id: version
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
-          case "${{ github.event_name }}" in
+          case "$EVENT_NAME" in
             pull_request)
               version=$(cat VERSION)
               ;;
             release)
-              version='${{ github.event.release.tag_name }}'
-              version=${version#v}
+              version=${RELEASE_TAG#v}
               ;;
             workflow_dispatch)
-              version='${{ inputs.version }}'
-              version=${version#v}
+              version=${DISPATCH_VERSION#v}
               ;;
             *)
-              printf 'unsupported event: %s\n' '${{ github.event_name }}' >&2
+              printf 'unsupported event: %s\n' "$EVENT_NAME" >&2
               exit 1
               ;;
           esac
+
+          [ -n "$version" ] || {
+            echo 'target version cannot be empty' >&2
+            exit 1
+          }
 
           dpkg --validate-version "$version"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -147,6 +147,10 @@ Before advertising upgrade support, exercise a real previous-version -> current-
 
 A signed hosted APT repository is a separate distribution layer and does not become implied merely because a `.deb` exists.
 
+When signed APT publication is enabled, `.github/workflows/publish-apt-repository.yml` assembles every stable published Debian package up to the target version, verifies each against its release `SHA256SUMS`, signs the resulting multiversion repository, validates it with an isolated APT client, and deploys the static tree to GitHub Pages. Pull requests exercise the same assembly/sign/validation path with an ephemeral key but never deploy.
+
+Production APT publication requires the dedicated signing subkey secrets and GitHub Pages configured with **Source: GitHub Actions**. A manual workflow dispatch can bootstrap or republish an existing stable version; stable future release publication can trigger the same workflow automatically.
+
 ## 7. Post-release verification
 
 After publication, verify:

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -117,6 +117,29 @@ The repository builder:
 
 The output path must not already exist. This prevents stale indexes or packages from being silently mixed into a new publication tree.
 
+For release publication automation, `PANTHEON_LOCAL_APT_CURRENT_VERSION` may explicitly select the version that must be present in the generated repository. Normal direct use defaults to the repository-root `VERSION`.
+
+### Assemble from published releases
+
+`build-published-apt-repository.sh` builds the publication input from GitHub Releases rather than rebuilding historical packages:
+
+```bash
+bash packaging/debian/build-published-apt-repository.sh \
+  dist/apt-repository \
+  zevarix/pantheon-local-tools \
+  VERSION
+```
+
+For every stable release up to and including the target version, the assembler:
+
+- downloads the versioned `.deb` plus that release's `SHA256SUMS`;
+- verifies the package bytes against the published checksum;
+- verifies package name, version, and `Architecture: all` metadata;
+- rejects a target version that is not a stable published release; and
+- feeds all verified historical packages into the multiversion repository builder.
+
+When `SOURCE_DATE_EPOCH` is not supplied, the target GitHub Release publication time is used so repeated assembly of the same target produces stable unsigned repository metadata.
+
 ### Sign repository metadata
 
 Signing is intentionally separate from repository generation:
@@ -137,7 +160,7 @@ It immediately verifies both signatures using the exported public keyring.
 
 Do **not** store a production private signing key, passphrase, or exported secret-key material in this repository, release assets, generated repository content, workflow logs, or public issue comments.
 
-CI validates the signing path with an ephemeral throwaway key. Production key creation, secure backup, rotation/recovery policy, and publication credentials are separate operational concerns.
+CI validates the signing path with an ephemeral throwaway key. `PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE` optionally supplies a passphrase to GPG through loopback pinentry, allowing the production signing subkey stored in Actions secrets to remain passphrase-protected. Production key creation, secure backup, rotation/recovery policy, and publication credentials are separate operational concerns.
 
 ### Client trust
 
@@ -157,6 +180,8 @@ The public repository URL and production key installation commands are documente
 
 ### Publication boundary
 
-Repository hosting and production signing are tracked separately from deterministic packaging. The current publication plan is an Actions-built static archive on the project's GitHub Pages site, with historical released `.deb` files retained so future upgrade and downgrade/reinstall tests remain possible.
+Repository hosting and production signing are tracked separately from deterministic packaging. `.github/workflows/publish-apt-repository.yml` performs a real publication dry run on relevant pull requests with an ephemeral key. Stable release events and manual dispatches use the configured production signing secrets, upload the generated static archive as a GitHub Pages artifact, and deploy it through the `github-pages` environment.
+
+The workflow intentionally assembles historical `.deb` files from their published GitHub Release assets rather than rebuilding old packages. GitHub Pages must be enabled with **Source: GitHub Actions** before the first production deployment, and the production signing secrets must be configured first.
 
 The first real package upgrade remains deferred until a second published Debian package exists.

--- a/packaging/debian/build-apt-repository.sh
+++ b/packaging/debian/build-apt-repository.sh
@@ -36,8 +36,8 @@ require_command tr
 require_command wc
 
 [ -f "$VERSION_FILE" ] || die "VERSION file not found: $VERSION_FILE"
-CURRENT_VERSION=$(cat "$VERSION_FILE")
-[ -n "$CURRENT_VERSION" ] || die 'VERSION cannot be empty'
+CURRENT_VERSION=${PANTHEON_LOCAL_APT_CURRENT_VERSION:-$(cat "$VERSION_FILE")}
+[ -n "$CURRENT_VERSION" ] || die 'current repository version cannot be empty'
 case "$CURRENT_VERSION" in
   *$'\n'*|*$'\r'*) die 'VERSION must be a single line' ;;
 esac

--- a/packaging/debian/build-published-apt-repository.sh
+++ b/packaging/debian/build-published-apt-repository.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME='pantheon-local-tools published APT repository builder'
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+[ "$#" -eq 3 ] ||
+  die 'usage: build-published-apt-repository.sh OUTPUT_DIR OWNER/REPO TARGET_VERSION'
+
+OUTPUT_DIR=$1
+REPOSITORY=$2
+TARGET_VERSION=${3#v}
+
+require_command awk
+require_command date
+require_command dpkg
+require_command dpkg-deb
+require_command gh
+require_command grep
+require_command mktemp
+require_command sha256sum
+
+case "$REPOSITORY" in
+  */*) ;;
+  *) die 'repository must use OWNER/REPO form' ;;
+esac
+
+[ -n "$TARGET_VERSION" ] || die 'target version cannot be empty'
+dpkg --validate-version "$TARGET_VERSION" >/dev/null 2>&1 ||
+  die "invalid Debian package version: $TARGET_VERSION"
+
+[ ! -e "$OUTPUT_DIR" ] || die "output path already exists: $OUTPUT_DIR"
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+TAGS_FILE="$TMP_ROOT/tags"
+PACKAGES_FILE="$TMP_ROOT/packages"
+: > "$TAGS_FILE"
+: > "$PACKAGES_FILE"
+
+gh api --paginate "repos/$REPOSITORY/releases?per_page=100" \
+  --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+  > "$TAGS_FILE"
+
+TARGET_FOUND=0
+
+while IFS= read -r tag; do
+  [ -n "$tag" ] || continue
+
+  case "$tag" in
+    v*) version=${tag#v} ;;
+    *) continue ;;
+  esac
+
+  dpkg --validate-version "$version" >/dev/null 2>&1 ||
+    die "stable release tag is not a valid Debian version: $tag"
+
+  if ! dpkg --compare-versions "$version" le "$TARGET_VERSION"; then
+    continue
+  fi
+
+  release_dir="$TMP_ROOT/releases/$version"
+  mkdir -p "$release_dir"
+
+  deb_name="pantheon-local-tools_${version}_all.deb"
+
+  gh release download "$tag" \
+    --repo "$REPOSITORY" \
+    --pattern "$deb_name" \
+    --pattern 'SHA256SUMS' \
+    --dir "$release_dir" >/dev/null
+
+  deb_file="$release_dir/$deb_name"
+  sums_file="$release_dir/SHA256SUMS"
+
+  [ -f "$deb_file" ] || die "release $tag is missing $deb_name"
+  [ -f "$sums_file" ] || die "release $tag is missing SHA256SUMS"
+
+  expected_sha=$(
+    awk -v file="$deb_name" '$2 == file { print $1 }' "$sums_file"
+  )
+
+  [ -n "$expected_sha" ] ||
+    die "release $tag SHA256SUMS does not contain $deb_name"
+  case "$expected_sha" in
+    *$'\n'*|*$'\r'*) die "release $tag has duplicate checksum entries for $deb_name" ;;
+  esac
+  printf '%s\n' "$expected_sha" | grep -Eq '^[0-9a-fA-F]{64}$' ||
+    die "release $tag has an invalid checksum for $deb_name"
+
+  actual_sha=$(sha256sum "$deb_file" | awk '{print $1}')
+  [ "$actual_sha" = "$expected_sha" ] ||
+    die "release $tag checksum mismatch for $deb_name"
+
+  [ "$(dpkg-deb -f "$deb_file" Package)" = 'pantheon-local-tools' ] ||
+    die "release $tag contains the wrong package name"
+  [ "$(dpkg-deb -f "$deb_file" Version)" = "$version" ] ||
+    die "release $tag package version does not match its tag"
+  [ "$(dpkg-deb -f "$deb_file" Architecture)" = 'all' ] ||
+    die "release $tag package architecture is not all"
+
+  printf '%s\n' "$deb_file" >> "$PACKAGES_FILE"
+
+  if [ "$version" = "$TARGET_VERSION" ]; then
+    TARGET_FOUND=1
+  fi
+done < "$TAGS_FILE"
+
+[ "$TARGET_FOUND" -eq 1 ] ||
+  die "stable published release v$TARGET_VERSION was not found"
+
+[ -s "$PACKAGES_FILE" ] || die 'no stable published Debian packages were found'
+
+if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
+  published_at=$(gh api "repos/$REPOSITORY/releases/tags/v$TARGET_VERSION" --jq '.published_at')
+  [ -n "$published_at" ] || die "published_at is missing for v$TARGET_VERSION"
+  SOURCE_DATE_EPOCH=$(date -u -d "$published_at" +%s)
+  export SOURCE_DATE_EPOCH
+fi
+
+packages=()
+while IFS= read -r package; do
+  [ -n "$package" ] || continue
+  packages+=("$package")
+done < "$PACKAGES_FILE"
+
+PANTHEON_LOCAL_APT_CURRENT_VERSION="$TARGET_VERSION" \
+  bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+    "$OUTPUT_DIR" "${packages[@]}" >/dev/null
+
+printf '%s\n' "$OUTPUT_DIR"

--- a/packaging/debian/sign-apt-repository.sh
+++ b/packaging/debian/sign-apt-repository.sh
@@ -42,11 +42,22 @@ gpg --batch --list-secret-keys "$SIGNING_KEY" >/dev/null 2>&1 ||
 
 rm -f "$INRELEASE" "$RELEASE_GPG" "$KEYRING"
 
-gpg --batch --yes --local-user "$SIGNING_KEY" --armor --clearsign \
-  --output "$INRELEASE" "$RELEASE"
+gpg_sign() {
+  output=$1
+  shift
 
-gpg --batch --yes --local-user "$SIGNING_KEY" --armor --detach-sign \
-  --output "$RELEASE_GPG" "$RELEASE"
+  if [ -n "${PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE:-}" ]; then
+    printf '%s' "$PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE" |
+      gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 \
+        --local-user "$SIGNING_KEY" "$@" --output "$output" "$RELEASE"
+  else
+    gpg --batch --yes --local-user "$SIGNING_KEY" \
+      "$@" --output "$output" "$RELEASE"
+  fi
+}
+
+gpg_sign "$INRELEASE" --armor --clearsign
+gpg_sign "$RELEASE_GPG" --armor --detach-sign
 
 gpg --batch --yes --export "$SIGNING_KEY" > "$KEYRING"
 [ -s "$KEYRING" ] || die 'public archive key export is empty'

--- a/tests/test-apt-repository.sh
+++ b/tests/test-apt-repository.sh
@@ -147,11 +147,24 @@ then
   fail 'repository builder accepted a repository without the current version'
 fi
 
+OVERRIDE_REPOSITORY="$TMP_ROOT/override-version-repository"
+PANTHEON_LOCAL_APT_CURRENT_VERSION="$OLDER_VERSION" \
+  bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+    "$OVERRIDE_REPOSITORY" "$OLDER_PACKAGE" >/dev/null
+
+grep -Fx "Version: $OLDER_VERSION" \
+  "$OVERRIDE_REPOSITORY/dists/stable/main/binary-all/Packages" >/dev/null ||
+  fail 'explicit repository target version did not build the requested version'
+
 GNUPGHOME="$TMP_ROOT/gnupg"
 export GNUPGHOME
 mkdir -m 0700 "$GNUPGHOME"
 
-gpg --batch --passphrase '' --quick-generate-key \
+TEST_SIGNING_PASSPHRASE='apt-test-passphrase'
+
+gpg --batch --pinentry-mode loopback \
+  --passphrase "$TEST_SIGNING_PASSPHRASE" \
+  --quick-generate-key \
   'Pantheon Local Tools CI <ci@example.invalid>' \
   rsa2048 sign 1d >/dev/null 2>&1
 
@@ -162,8 +175,9 @@ SIGNING_KEY=$(
 
 [ -n "$SIGNING_KEY" ] || fail 'ephemeral signing key fingerprint is missing'
 
-bash "$REPO_ROOT/packaging/debian/sign-apt-repository.sh" \
-  "$REPOSITORY_ONE" "$SIGNING_KEY" >/dev/null
+PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE="$TEST_SIGNING_PASSPHRASE" \
+  bash "$REPO_ROOT/packaging/debian/sign-apt-repository.sh" \
+    "$REPOSITORY_ONE" "$SIGNING_KEY" >/dev/null
 
 INRELEASE="$REPOSITORY_ONE/dists/stable/InRelease"
 RELEASE_GPG="$REPOSITORY_ONE/dists/stable/Release.gpg"


### PR DESCRIPTION
## Summary

Advance #36 by wiring the non-secret signed APT publication path around the repository tooling completed in #35.

This PR:

- allows publication tooling to explicitly select the target repository version while preserving the normal `VERSION` default;
- supports passphrase-protected GPG signing through loopback pinentry;
- adds a release assembler that downloads stable published `.deb` assets and verifies each against its release `SHA256SUMS` before indexing;
- preserves all stable published Debian versions in the multiversion APT repository;
- adds a GitHub Pages publication workflow whose pull-request path uses an ephemeral signing key and never deploys;
- keeps production deployment gated on the dedicated signing secrets and GitHub Pages configuration;
- documents the release/publication boundary and the manual bootstrap/republish path.

Local WSL2 validation assembled the real published v0.1.0 release, verified its published checksum, signed the generated repository with a temporary passphrase-protected key, verified the signature, and passed the full repository test suite.

This does not create or store the production archive signing key and does not yet enable GitHub Pages. Those one-time operational steps and real public-client validation remain in #36.

Refs #36.