### PR TITLE
Harden APT publication boundaries

### DIFF
--- a/.github/workflows/publish-apt-repository.yml
+++ b/.github/workflows/publish-apt-repository.yml
@@ -52,7 +52,10 @@ jobs:
 
           case "$EVENT_NAME" in
             pull_request)
-              version=$(cat VERSION)
+              release_tag=$(
+                gh api "repos/$GITHUB_REPOSITORY/releases/latest"                   --jq '.tag_name'
+              )
+              version=${release_tag#v}
               ;;
             release)
               version=${RELEASE_TAG#v}
@@ -76,12 +79,14 @@ jobs:
 
       - name: Assemble verified repository from stable releases
         shell: bash
+        env:
+          TARGET_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           bash packaging/debian/build-published-apt-repository.sh \
             "$RUNNER_TEMP/apt-repository" \
             "$GITHUB_REPOSITORY" \
-            '${{ steps.version.outputs.version }}'
+            "$TARGET_VERSION"
 
       - name: Sign dry-run repository with ephemeral key
         if: github.event_name == 'pull_request'
@@ -146,12 +151,14 @@ jobs:
 
       - name: Validate signed repository with isolated APT client
         shell: bash
+        env:
+          TARGET_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
 
           repository="$RUNNER_TEMP/apt-repository"
           keyring="$repository/pantheon-local-tools-archive-keyring.gpg"
-          version='${{ steps.version.outputs.version }}'
+          version="$TARGET_VERSION"
 
           gpgv --keyring "$keyring" \
             "$repository/dists/stable/InRelease" >/dev/null

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -147,7 +147,7 @@ Before advertising upgrade support, exercise a real previous-version -> current-
 
 A signed hosted APT repository is a separate distribution layer and does not become implied merely because a `.deb` exists.
 
-When signed APT publication is enabled, `.github/workflows/publish-apt-repository.yml` assembles every stable published Debian package up to the target version, verifies each against its release `SHA256SUMS`, signs the resulting multiversion repository, validates it with an isolated APT client, and deploys the static tree to GitHub Pages. Pull requests exercise the same assembly/sign/validation path with an ephemeral key but never deploy.
+When signed APT publication is enabled, `.github/workflows/publish-apt-repository.yml` assembles every stable published Debian package up to the target version, verifies each against its release `SHA256SUMS`, signs the resulting multiversion repository, validates it with an isolated APT client, and deploys the static tree to GitHub Pages. Pull requests exercise the same assembly/sign/validation path against the latest already-published stable release with an ephemeral key, but never deploy.
 
 Production APT publication requires the dedicated signing subkey secrets and GitHub Pages configured with **Source: GitHub Actions**. A manual workflow dispatch can bootstrap or republish an existing stable version; stable future release publication can trigger the same workflow automatically.
 

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -180,7 +180,7 @@ The public repository URL and production key installation commands are documente
 
 ### Publication boundary
 
-Repository hosting and production signing are tracked separately from deterministic packaging. `.github/workflows/publish-apt-repository.yml` performs a real publication dry run on relevant pull requests with an ephemeral key. Stable release events and manual dispatches use the configured production signing secrets, upload the generated static archive as a GitHub Pages artifact, and deploy it through the `github-pages` environment.
+Repository hosting and production signing are tracked separately from deterministic packaging. `.github/workflows/publish-apt-repository.yml` performs a real publication dry run on relevant pull requests with an ephemeral key against the latest already-published stable release. Stable release events and manual dispatches use the configured production signing secrets, upload the generated static archive as a GitHub Pages artifact, and deploy it through the `github-pages` environment.
 
 The workflow intentionally assembles historical `.deb` files from their published GitHub Release assets rather than rebuilding old packages. GitHub Pages must be enabled with **Source: GitHub Actions** before the first production deployment, and the production signing secrets must be configured first.
 

--- a/packaging/debian/build-apt-repository.sh
+++ b/packaging/debian/build-apt-repository.sh
@@ -39,7 +39,7 @@ require_command wc
 CURRENT_VERSION=${PANTHEON_LOCAL_APT_CURRENT_VERSION:-$(cat "$VERSION_FILE")}
 [ -n "$CURRENT_VERSION" ] || die 'current repository version cannot be empty'
 case "$CURRENT_VERSION" in
-  *$'\n'*|*$'\r'*) die 'VERSION must be a single line' ;;
+  *$'\n'*|*$'\r'*) die 'current repository version must be a single line' ;;
 esac
 
 case "$OUTPUT_DIR" in


### PR DESCRIPTION
## Summary

Follow up on #38 with a small publication-boundary hardening pass before production signing is enabled.

This PR:

- makes pull-request publication dry runs target the latest already-published stable release instead of the checkout `VERSION`, so future release-prep PRs do not fail simply because the new version is not published yet;
- passes the resolved target version to later shell steps through environment variables rather than interpolating it into shell source;
- tightens the repository-builder validation message; and
- updates the APT/release documentation to describe the dry-run target accurately.

Local validation resolved the current latest stable release successfully and preserved noreply author/committer identity.

Refs #36.