### PR TITLE
Validate and document the public APT repository

### DIFF
--- a/.github/workflows/publish-apt-repository.yml
+++ b/.github/workflows/publish-apt-repository.yml
@@ -53,7 +53,8 @@ jobs:
           case "$EVENT_NAME" in
             pull_request)
               release_tag=$(
-                gh api "repos/$GITHUB_REPOSITORY/releases/latest"                   --jq '.tag_name'
+                gh api "repos/$GITHUB_REPOSITORY/releases/latest" \
+                  --jq '.tag_name'
               )
               version=${release_tag#v}
               ;;
@@ -122,6 +123,7 @@ jobs:
         env:
           APT_SIGNING_PRIVATE_KEY: ${{ secrets.APT_SIGNING_PRIVATE_KEY }}
           APT_SIGNING_PASSPHRASE: ${{ secrets.APT_SIGNING_PASSPHRASE }}
+          APT_SIGNING_SUBKEY_FINGERPRINT: ${{ secrets.APT_SIGNING_SUBKEY_FINGERPRINT }}
         run: |
           set -euo pipefail
 
@@ -134,20 +136,51 @@ jobs:
           mkdir -m 0700 "$GNUPGHOME"
           printf '%s\n' "$APT_SIGNING_PRIVATE_KEY" | gpg --batch --import >/dev/null 2>&1
 
-          fingerprint=$(
+          primary_fingerprint=$(
             gpg --batch --with-colons --list-secret-keys |
               awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
           )
 
-          [ -n "$fingerprint" ] || {
+          [ -n "$primary_fingerprint" ] || {
             echo 'production signing key fingerprint could not be resolved' >&2
             exit 1
           }
 
+          signing_fingerprint=$primary_fingerprint
+          exact_signing_key=0
+
+          if [ -n "$APT_SIGNING_SUBKEY_FINGERPRINT" ]; then
+            printf '%s\n' "$APT_SIGNING_SUBKEY_FINGERPRINT" |
+              grep -Eq '^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$' || {
+                echo 'APT_SIGNING_SUBKEY_FINGERPRINT must be a full fingerprint' >&2
+                exit 1
+              }
+
+            gpg --batch --with-colons \
+              --list-secret-keys "$APT_SIGNING_SUBKEY_FINGERPRINT" |
+              awk -F: -v wanted="$APT_SIGNING_SUBKEY_FINGERPRINT" '
+                $1 == "ssb" { want_fpr = 1; next }
+                want_fpr && $1 == "fpr" {
+                  if (toupper($10) == toupper(wanted)) {
+                    found = 1
+                  }
+                  want_fpr = 0
+                }
+                END { exit found ? 0 : 1 }
+              ' || {
+                echo 'configured exact signer is not an imported secret subkey' >&2
+                exit 1
+              }
+
+            signing_fingerprint=$APT_SIGNING_SUBKEY_FINGERPRINT
+            exact_signing_key=1
+          fi
+
           PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE="$APT_SIGNING_PASSPHRASE" \
+          PANTHEON_LOCAL_APT_EXACT_SIGNING_KEY="$exact_signing_key" \
             bash packaging/debian/sign-apt-repository.sh \
               "$RUNNER_TEMP/apt-repository" \
-              "$fingerprint"
+              "$signing_fingerprint"
 
       - name: Validate signed repository with isolated APT client
         shell: bash

--- a/.github/workflows/validate-published-apt.yml
+++ b/.github/workflows/validate-published-apt.yml
@@ -1,0 +1,179 @@
+name: Validate published APT repository
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/validate-published-apt.yml'
+      - 'docs/apt-repository.md'
+      - 'packaging/debian/README.md'
+      - 'README.md'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/validate-published-apt.yml'
+      - 'docs/apt-repository.md'
+      - 'packaging/debian/README.md'
+      - 'README.md'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published package version to validate
+        required: true
+        default: '0.1.0'
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  APT_REPOSITORY_URL: https://zevarix.github.io/pantheon-local-tools
+  APT_PRIMARY_FINGERPRINT: B75C45FA9E87AF56D7677F5785AF0D1C6E64C3F2
+
+jobs:
+  public-apt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install validation prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ca-certificates curl gnupg
+
+      - name: Resolve validation target
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          version=${DISPATCH_VERSION:-0.1.0}
+          [ -n "$version" ] || {
+            echo 'package version cannot be empty' >&2
+            exit 1
+          }
+          dpkg --validate-version "$version"
+          printf 'PACKAGE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
+      - name: Download and verify archive key
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          keyring="$RUNNER_TEMP/pantheon-local-tools-archive-keyring.gpg"
+          curl --fail --silent --show-error --location \
+            "$APT_REPOSITORY_URL/pantheon-local-tools-archive-keyring.gpg" \
+            --output "$keyring"
+
+          fingerprint=$(
+            gpg --batch --show-keys --with-colons "$keyring" |
+              awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+          )
+
+          [ "$fingerprint" = "$APT_PRIMARY_FINGERPRINT" ] || {
+            printf 'expected archive fingerprint %s, got %s\n' \
+              "$APT_PRIMARY_FINGERPRINT" "$fingerprint" >&2
+            exit 1
+          }
+
+          sudo install -d -m 0755 /etc/apt/keyrings
+          sudo install -m 0644 \
+            "$keyring" \
+            /etc/apt/keyrings/pantheon-local-tools.gpg
+
+      - name: Configure repository and discover package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > "$RUNNER_TEMP/pantheon-local-tools.sources" <<EOF
+          Types: deb
+          URIs: $APT_REPOSITORY_URL
+          Suites: stable
+          Components: main
+          Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
+          EOF
+
+          sudo install -m 0644 \
+            "$RUNNER_TEMP/pantheon-local-tools.sources" \
+            /etc/apt/sources.list.d/pantheon-local-tools.sources
+
+          sudo apt-get update
+
+          candidate=$(
+            apt-cache policy pantheon-local-tools |
+              awk '/Candidate:/ && !found { print $2; found = 1 }'
+          )
+
+          [ "$candidate" = "$PACKAGE_VERSION" ] || {
+            printf 'expected candidate %s, got %s\n' \
+              "$PACKAGE_VERSION" "$candidate" >&2
+            exit 1
+          }
+
+      - name: Install and verify published package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ! dpkg-query -W -f='${Status}\n' pantheon-local-tools 2>/dev/null |
+            grep -qx 'install ok installed'
+          [ ! -e /usr/bin/pantheon-local ]
+
+          sudo apt-get install --yes \
+            "pantheon-local-tools=$PACKAGE_VERSION"
+
+          [ "$(dpkg-query -W -f='${Version}' pantheon-local-tools)" = \
+            "$PACKAGE_VERSION" ]
+          [ "$(/usr/bin/pantheon-local --version)" = \
+            "pantheon-local $PACKAGE_VERSION" ]
+          [ "$(readlink -f /usr/bin/pantheon-local)" = \
+            '/usr/lib/pantheon-local-tools/bin/pantheon-local' ]
+
+      - name: Verify reinstall and configuration preservation
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          config="$RUNNER_TEMP/pantheon-local-tools-config"
+          PANTHEON_LOCAL_CONFIG="$config" \
+            /usr/bin/pantheon-local config set provider ddev
+
+          [ "$(
+            PANTHEON_LOCAL_CONFIG="$config" \
+              /usr/bin/pantheon-local config get provider
+          )" = 'ddev' ]
+
+          sudo apt-get install --yes --reinstall \
+            "pantheon-local-tools=$PACKAGE_VERSION"
+
+          [ "$(
+            PANTHEON_LOCAL_CONFIG="$config" \
+              /usr/bin/pantheon-local config get provider
+          )" = 'ddev' ]
+          [ -f "$config" ]
+
+      - name: Verify uninstall and user-state preservation
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          config="$RUNNER_TEMP/pantheon-local-tools-config"
+          sudo apt-get remove --yes pantheon-local-tools
+          hash -r
+
+          ! dpkg-query -W -f='${Status}\n' pantheon-local-tools 2>/dev/null |
+            grep -qx 'install ok installed'
+          [ ! -e /usr/bin/pantheon-local ]
+          [ ! -e /usr/lib/pantheon-local-tools ]
+          ! type -P pantheon-local >/dev/null 2>&1
+          [ -f "$config" ]
+          [ "$(git config --file "$config" --get local.provider)" = 'ddev' ]
+
+      - name: Remove validation APT source
+        if: always()
+        shell: bash
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/pantheon-local-tools.sources \
+            /etc/apt/keyrings/pantheon-local-tools.gpg

--- a/README.md
+++ b/README.md
@@ -254,23 +254,40 @@ The publishable formula is generated only from the immutable release source arti
 
 ### Debian / Ubuntu / WSL
 
-An architecture-independent Debian package builder is implemented and tested on Ubuntu and WSL2:
+The v0.1.0 Debian package is published both as a downloadable release artifact and through the signed APT repository:
+
+```text
+https://zevarix.github.io/pantheon-local-tools
+```
+
+The repository uses a dedicated `/etc/apt/keyrings` keyring and deb822 `Signed-By` source. Because the archive key is a trust anchor, follow the fingerprint-verifying installation procedure in [`docs/apt-repository.md`](docs/apt-repository.md) rather than piping an unverified key directly into APT.
+
+After the repository is configured, installation is the normal APT path:
+
+```bash
+sudo apt-get update
+sudo apt-get install pantheon-local-tools
+```
+
+The public v0.1.0 repository path has completed real WSL2 validation and clean GitHub-hosted Ubuntu validation, including archive fingerprint/signature verification, `apt update`, candidate discovery, install, CLI/config checks, reinstall with configuration preservation, and uninstall. A real previous-version to newer-version upgrade remains deferred to #30 because v0.1.0 is the first published Debian package.
+
+The architecture-independent package builder remains available to maintainers and contributors:
 
 ```bash
 bash packaging/debian/build-deb.sh
 ```
 
-Tagged releases may attach `pantheon-local-tools_<VERSION>_all.deb`. A downloaded package installs with:
+A downloaded GitHub Release package can also be installed directly:
 
 ```bash
 sudo apt install ./pantheon-local-tools_<VERSION>_all.deb
 ```
 
-The package installs application files under `/usr/lib/pantheon-local-tools`, exposes `/usr/bin/pantheon-local`, and leaves user configuration/checkouts outside package ownership. Real package install/upgrade/uninstall validation and any hosted signed APT repository remain follow-up distribution work tracked in #9; they are not implied by shipping the first `.deb`. See [`packaging/debian/README.md`](packaging/debian/README.md).
+The package installs application files under `/usr/lib/pantheon-local-tools`, exposes `/usr/bin/pantheon-local`, and leaves user configuration/checkouts outside package ownership. See [`packaging/debian/README.md`](packaging/debian/README.md) for package/repository implementation details.
 
 The clone installer remains supported as the portable fallback for macOS, Linux, WSL, contributors, and CI even after package-manager distribution is published.
 
-Maintainers should follow [`docs/releasing.md`](docs/releasing.md) for the tag, deterministic source archive, checksums, GitHub Release, Homebrew formula, and Debian artifact sequence. Real provider/host release gates are in [`docs/real-integration-validation.md`](docs/real-integration-validation.md).
+Maintainers should follow [`docs/releasing.md`](docs/releasing.md) for the tag, deterministic source archive, checksums, GitHub Release, Homebrew formula, Debian artifact, and signed APT publication sequence. Real provider/host release gates are in [`docs/real-integration-validation.md`](docs/real-integration-validation.md).
 
 ## Development
 
@@ -290,7 +307,7 @@ Run ShellCheck when available:
 shellcheck bin/pantheon-local libexec/pantheon-local-* install.sh tests/test-*.sh packaging/debian/*.sh packaging/homebrew/*.sh packaging/release/*.sh
 ```
 
-CI runs syntax validation, ShellCheck, and the full shell integration suite on both Ubuntu and macOS. The suite includes isolated-home installer coverage, provider mocks, deterministic release-source packaging, Ubuntu `.deb` layout validation, and macOS Homebrew temporary-tap installation. Real WSL2 fresh-clone/install/full-suite validation is also complete for v0.1.0.
+CI runs syntax validation, ShellCheck, and the full shell integration suite on both Ubuntu and macOS. The suite includes isolated-home installer coverage, provider mocks, deterministic release-source packaging, Ubuntu `.deb` layout validation, signed APT repository generation/signing checks, and macOS Homebrew temporary-tap installation. Real WSL2 fresh-clone/install/full-suite validation is also complete for v0.1.0, and the published APT repository has its own clean hosted-Ubuntu smoke workflow.
 
 ## Contributing
 

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -1,0 +1,138 @@
+# Signed APT repository
+
+Pantheon Local Tools publishes a signed Debian/Ubuntu/WSL repository at:
+
+```text
+https://zevarix.github.io/pantheon-local-tools
+```
+
+The repository uses the `stable` suite and `main` component. Client trust is scoped to a dedicated keyring through APT's `Signed-By` mechanism; `apt-key` is not used.
+
+## Install from the repository
+
+Install the small set of tools used to retrieve and verify the archive key:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes ca-certificates curl gnupg
+```
+
+Download the public archive keyring and verify its primary fingerprint before installing it:
+
+```bash
+EXPECTED_FINGERPRINT='B75C45FA9E87AF56D7677F5785AF0D1C6E64C3F2'
+KEYRING=$(mktemp)
+
+curl --fail --silent --show-error --location \
+  https://zevarix.github.io/pantheon-local-tools/pantheon-local-tools-archive-keyring.gpg \
+  --output "$KEYRING"
+
+ACTUAL_FINGERPRINT=$(
+  gpg --batch --show-keys --with-colons "$KEYRING" |
+    awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+)
+
+[ "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT" ] || {
+  printf 'archive key fingerprint mismatch: %s\n' "$ACTUAL_FINGERPRINT" >&2
+  rm -f "$KEYRING"
+  exit 1
+}
+
+sudo install -d -m 0755 /etc/apt/keyrings
+sudo install -m 0644 \
+  "$KEYRING" \
+  /etc/apt/keyrings/pantheon-local-tools.gpg
+rm -f "$KEYRING"
+```
+
+Configure the repository with a deb822 source:
+
+```bash
+sudo tee /etc/apt/sources.list.d/pantheon-local-tools.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://zevarix.github.io/pantheon-local-tools
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
+EOF
+
+sudo apt-get update
+sudo apt-get install pantheon-local-tools
+```
+
+Verify the installed command with:
+
+```bash
+pantheon-local --version
+```
+
+APT will use the published repository for later package upgrades when newer stable versions exist.
+
+## Remove the package or repository
+
+Removing the Debian package does not remove user configuration or checkout-local state:
+
+```bash
+sudo apt-get remove pantheon-local-tools
+```
+
+To stop using the repository as well, remove only its dedicated source and keyring, then refresh APT:
+
+```bash
+sudo rm -f \
+  /etc/apt/sources.list.d/pantheon-local-tools.sources \
+  /etc/apt/keyrings/pantheon-local-tools.gpg
+sudo apt-get update
+```
+
+## Publication trust model
+
+The archive identity uses a certification-capable primary OpenPGP key kept out of normal online publication infrastructure. Repository metadata is signed by a separate signing subkey. GitHub Actions stores only the minimum passphrase-protected signing-subkey material needed to publish; the certification-capable primary secret is not stored in the repository, release assets, Pages content, workflow artifacts, or Actions signing secret.
+
+The initial operational policy is:
+
+- primary key: certification only, five-year expiration;
+- signing subkey: signing only, one-year expiration;
+- begin normal signing-subkey rotation at least 30 days before expiration;
+- keep an encrypted full recovery bundle on offline/removable storage;
+- keep the recovery-key passphrase separately from that backup; and
+- publish only public key material to the APT repository.
+
+The public primary fingerprint is:
+
+```text
+B75C45FA9E87AF56D7677F5785AF0D1C6E64C3F2
+```
+
+## Signing-subkey rotation
+
+A signing-subkey rotation keeps the same primary archive identity, but clients still need a refreshed `/etc/apt/keyrings/pantheon-local-tools.gpg` containing the new subkey before repository metadata switches to that subkey. The primary fingerprint staying constant does **not** make an old local keyring learn new subkeys automatically.
+
+Use an overlap procedure:
+
+1. On a trusted offline system, restore the full recovery key and verify the expected primary fingerprint.
+2. Add a new signing-only subkey while the previous signing subkey is still valid. Use an overlapping validity window; do not revoke or expire the old signer yet.
+3. Export a refreshed public archive keyring and verify that the primary fingerprint is unchanged and that both the old and new signing subkeys are present.
+4. Publish the refreshed public keyring and update the installation/rotation notice while repository metadata is still signed by the old subkey. When tooling contains multiple usable signing subkeys, select the old signing subkey explicitly rather than relying on GPG's implicit subkey choice.
+5. Give existing clients a transition window to reinstall the dedicated keyring using the fingerprint-verified procedure above.
+6. Replace the Actions signing-subkey export with the new minimum secret material, select the new signing subkey explicitly, manually republish the current stable repository, and verify the public `InRelease` signature plus a clean APT client.
+7. Keep the old signing subkey valid through the announced overlap period. Retire or revoke it only after the transition is complete and the refreshed public keyring/recovery bundle is safely stored.
+8. Record the new signing-subkey expiration and schedule the next rotation at least 30 days before it.
+
+The repository publication workflow must never depend on automatic GPG subkey selection during a rotation involving multiple usable signing subkeys.
+
+## Revocation and recovery
+
+If the Actions signing secret is lost but the signing subkey is not suspected compromised, restore only the passphrase-protected signing-subkey export from the offline recovery bundle, replace the Actions secret, and manually republish the current stable repository. Verify the public signature and APT client path afterward.
+
+If a signing subkey is suspected compromised, stop automated publication, restore the offline primary key, revoke the affected signing subkey, create a replacement signing subkey, and publish a refreshed public keyring with an explicit transition notice. Existing clients must refresh their dedicated keyring before metadata is signed only by the replacement subkey.
+
+If the certification-capable primary key itself is lost or compromised, a new archive identity is required. Do not silently substitute a different primary key under the existing fingerprint documentation. Publish a migration notice, document the new fingerprint through an independently reviewable repository change, and require clients to replace the dedicated keyring explicitly.
+
+Never place a private primary key, private signing subkey, passphrase, decrypted recovery bundle, or revocation secret in source control, release assets, Pages content, issue comments, or workflow logs.
+
+## Validation status
+
+The initial v0.1.0 repository has been published through GitHub Pages with signed `InRelease`/`Release.gpg` metadata. The public WSL2 path has been exercised through `apt update`, candidate discovery, install, CLI/config verification, reinstall with configuration preservation, uninstall, and package-file removal. `.github/workflows/validate-published-apt.yml` provides the corresponding clean GitHub-hosted Ubuntu validation against the public URL.
+
+A real previous-version to newer-version upgrade remains deferred until a second stable Debian package has actually been published.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -132,7 +132,7 @@ Then verify the installed `pantheon-local --version`, configuration path/write/r
 
 The repository CI already proves the same formula layout through an isolated temporary tap before publication; the released tap check proves the actual end-user distribution path.
 
-## 6. Validate the Debian release artifact
+## 6. Validate and publish the Debian/APT release
 
 For a downloaded release package on Ubuntu/Debian:
 
@@ -145,11 +145,21 @@ Verify user configuration remains outside package ownership and survives package
 
 Before advertising upgrade support, exercise a real previous-version -> current-version package upgrade. WSL/WSL2 requires its own real validation pass; Ubuntu CI is useful contract evidence but is not a substitute for WSL runtime proof.
 
-A signed hosted APT repository is a separate distribution layer and does not become implied merely because a `.deb` exists.
+The signed hosted APT repository is published separately from the downloadable `.deb` at:
 
-When signed APT publication is enabled, `.github/workflows/publish-apt-repository.yml` assembles every stable published Debian package up to the target version, verifies each against its release `SHA256SUMS`, signs the resulting multiversion repository, validates it with an isolated APT client, and deploys the static tree to GitHub Pages. Pull requests exercise the same assembly/sign/validation path against the latest already-published stable release with an ephemeral key, but never deploy.
+```text
+https://zevarix.github.io/pantheon-local-tools
+```
 
-Production APT publication requires the dedicated signing subkey secrets and GitHub Pages configured with **Source: GitHub Actions**. A manual workflow dispatch can bootstrap or republish an existing stable version; stable future release publication can trigger the same workflow automatically.
+`.github/workflows/publish-apt-repository.yml` assembles every stable published Debian package up to the target version, verifies each against its release `SHA256SUMS`, signs the resulting multiversion repository, validates it with an isolated APT client, and deploys the static tree to GitHub Pages. Pull requests exercise the same assembly/sign/validation path against the latest already-published stable release with an ephemeral key, but never deploy.
+
+Production APT publication uses the passphrase-protected signing-subkey material stored in the dedicated Actions secrets. The certification-capable primary key stays offline. When the optional `APT_SIGNING_SUBKEY_FINGERPRINT` secret is configured, publication forces GPG to use that exact imported signing subkey; use this during rotation overlap rather than relying on implicit GPG subkey selection.
+
+Stable non-prerelease GitHub Release publication triggers the APT publication workflow automatically. A manual workflow dispatch can bootstrap or republish an existing stable version without rebuilding historical package artifacts.
+
+After each APT publication, verify the real public path with `.github/workflows/validate-published-apt.yml` and, for release gates that require it, a WSL2 client. The clean hosted-Ubuntu workflow verifies the pinned archive fingerprint, `apt update`, candidate discovery, package installation, CLI/config behavior, reinstall with user-configuration preservation, and uninstall.
+
+Client trust, the pinned public fingerprint, keyring refresh, signing-subkey rotation, revocation, and recovery procedures are defined in [`docs/apt-repository.md`](apt-repository.md). A signing-subkey rotation must preserve an overlap window: publish a refreshed keyring while still signing with the old explicitly selected subkey, allow clients to refresh their dedicated keyring, then switch the exact signer and validate again.
 
 ## 7. Post-release verification
 
@@ -161,6 +171,9 @@ After publication, verify:
 - clean Homebrew installation from `zevarix/tap`;
 - Homebrew test and uninstall;
 - Debian installation when shipped;
+- signed APT repository fingerprint/signature and package discovery when Debian distribution is enabled;
+- clean hosted-Ubuntu APT install/reinstall/uninstall through the public HTTPS repository;
+- required WSL2 APT validation through the same public repository;
 - configuration remains user-owned;
 - no provider/project state is created merely by package installation; and
 - the portable clone installer remains documented and functional.
@@ -170,3 +183,5 @@ Only then mark the corresponding release-tracker items complete.
 ## Recovery rule
 
 If a published artifact or package metadata is wrong, preserve evidence and correct it explicitly. Do not silently move an existing release tag to different source bytes or replace a checksum without documenting the correction. Prefer a new patch release when users may already have consumed the published artifact.
+
+If an APT signing key or subkey is suspected compromised, stop automated APT publication and follow the revocation/recovery procedure in [`docs/apt-repository.md`](apt-repository.md) before publishing new metadata.

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -71,7 +71,13 @@ Package removal does not own that file and therefore must not delete it. Checkou
 
 ## Signed APT repository
 
-The hosted APT repository is a separate distribution layer from the downloadable `.deb`.
+The hosted APT repository is a separate distribution layer from the downloadable `.deb` and is published at:
+
+```text
+https://zevarix.github.io/pantheon-local-tools
+```
+
+End-user key verification, `/etc/apt/keyrings` installation, deb822 `Signed-By` setup, removal, signing-key rotation, revocation, and recovery procedures are documented in [`docs/apt-repository.md`](../../docs/apt-repository.md).
 
 Repository tooling uses a conventional Debian archive layout:
 
@@ -160,28 +166,34 @@ It immediately verifies both signatures using the exported public keyring.
 
 Do **not** store a production private signing key, passphrase, or exported secret-key material in this repository, release assets, generated repository content, workflow logs, or public issue comments.
 
-CI validates the signing path with an ephemeral throwaway key. `PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE` optionally supplies a passphrase to GPG through loopback pinentry, allowing the production signing subkey stored in Actions secrets to remain passphrase-protected. Production key creation, secure backup, rotation/recovery policy, and publication credentials are separate operational concerns.
+CI validates the signing path with ephemeral throwaway keys. `PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE` optionally supplies a passphrase to GPG through loopback pinentry, allowing the production signing subkey stored in Actions secrets to remain passphrase-protected.
+
+When multiple usable signing subkeys exist during a rotation overlap, set `PANTHEON_LOCAL_APT_EXACT_SIGNING_KEY=1` and pass the exact signing-subkey fingerprint. The signer appends GPG's exact-key selector (`!`) so publication never depends on implicit subkey choice. Production Actions can supply that fingerprint through the optional `APT_SIGNING_SUBKEY_FINGERPRINT` repository secret; with no such secret, the existing single-subkey behavior remains unchanged.
+
+Production key creation, secure backup, rotation/recovery policy, and publication credentials remain operational concerns documented in [`docs/apt-repository.md`](../../docs/apt-repository.md), not source-controlled secrets.
 
 ### Client trust
 
-The final public repository will use a dedicated keyring under `/etc/apt/keyrings` and APT's `Signed-By` mechanism. It must not use deprecated `apt-key` or add the archive key to global APT trust.
+Clients use a dedicated keyring under `/etc/apt/keyrings` and APT's `Signed-By` mechanism. The project does not use deprecated `apt-key` or add the archive key to global APT trust.
 
-The intended deb822 source shape is:
+The live deb822 source is:
 
 ```text
 Types: deb
-URIs: <APT_REPOSITORY_URL>
+URIs: https://zevarix.github.io/pantheon-local-tools
 Suites: stable
 Components: main
 Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
 ```
 
-The public repository URL and production key installation commands are documented only after the repository is actually published and verified.
+Do not install the keyring without verifying the documented primary fingerprint first. The complete copy/paste-safe client procedure and current public fingerprint are in [`docs/apt-repository.md`](../../docs/apt-repository.md).
 
 ### Publication boundary
 
-Repository hosting and production signing are tracked separately from deterministic packaging. `.github/workflows/publish-apt-repository.yml` performs a real publication dry run on relevant pull requests with an ephemeral key against the latest already-published stable release. Stable release events and manual dispatches use the configured production signing secrets, upload the generated static archive as a GitHub Pages artifact, and deploy it through the `github-pages` environment.
+`.github/workflows/publish-apt-repository.yml` performs a real publication dry run on relevant pull requests with an ephemeral key against the latest already-published stable release. Stable release events and manual dispatches use the configured production signing-subkey secrets, upload the generated static archive as a GitHub Pages artifact, and deploy it through the `github-pages` environment.
 
-The workflow intentionally assembles historical `.deb` files from their published GitHub Release assets rather than rebuilding old packages. GitHub Pages must be enabled with **Source: GitHub Actions** before the first production deployment, and the production signing secrets must be configured first.
+GitHub Pages is enabled with **Source: GitHub Actions**, and the initial v0.1.0 repository has been published and signature-verified through the real public URL. The workflow intentionally assembles historical `.deb` files from their published GitHub Release assets rather than rebuilding old packages.
 
-The first real package upgrade remains deferred until a second published Debian package exists.
+`.github/workflows/validate-published-apt.yml` exercises the public HTTPS repository on clean hosted Ubuntu, including archive fingerprint verification, `apt update`, candidate discovery, install, reinstall with user-configuration preservation, and uninstall. The same public v0.1.0 path has also completed real WSL2 validation.
+
+The first real previous-version to newer-version package upgrade remains deferred until a second published Debian package exists.

--- a/packaging/debian/sign-apt-repository.sh
+++ b/packaging/debian/sign-apt-repository.sh
@@ -40,6 +40,21 @@ printf '%s\n' "$SIGNING_KEY" |
 gpg --batch --list-secret-keys "$SIGNING_KEY" >/dev/null 2>&1 ||
   die 'signing secret key is not available'
 
+case "${PANTHEON_LOCAL_APT_EXACT_SIGNING_KEY:-0}" in
+  0)
+    GPG_LOCAL_USER=$SIGNING_KEY
+    ;;
+  1)
+    # A trailing ! tells GPG to use this exact primary key/subkey instead of
+    # applying its normal signing-subkey selection. This is important during
+    # rotation overlap when more than one signing subkey may be usable.
+    GPG_LOCAL_USER="${SIGNING_KEY}!"
+    ;;
+  *)
+    die 'PANTHEON_LOCAL_APT_EXACT_SIGNING_KEY must be 0 or 1'
+    ;;
+esac
+
 rm -f "$INRELEASE" "$RELEASE_GPG" "$KEYRING"
 
 gpg_sign() {
@@ -49,9 +64,9 @@ gpg_sign() {
   if [ -n "${PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE:-}" ]; then
     printf '%s' "$PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE" |
       gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 \
-        --local-user "$SIGNING_KEY" "$@" --output "$output" "$RELEASE"
+        --local-user "$GPG_LOCAL_USER" "$@" --output "$output" "$RELEASE"
   else
-    gpg --batch --yes --local-user "$SIGNING_KEY" \
+    gpg --batch --yes --local-user "$GPG_LOCAL_USER" \
       "$@" --output "$output" "$RELEASE"
   fi
 }
@@ -59,6 +74,9 @@ gpg_sign() {
 gpg_sign "$INRELEASE" --armor --clearsign
 gpg_sign "$RELEASE_GPG" --armor --detach-sign
 
+# Exporting by either the primary fingerprint or one of its subkey
+# fingerprints yields the complete corresponding public key, including
+# sibling subkeys needed by clients during a rotation overlap.
 gpg --batch --yes --export "$SIGNING_KEY" > "$KEYRING"
 [ -s "$KEYRING" ] || die 'public archive key export is empty'
 

--- a/tests/test-apt-signing-subkey-selection.sh
+++ b/tests/test-apt-signing-subkey-selection.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+chmod 0755 "$TMP_ROOT"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "expected [$2], got [$1]"
+}
+
+for command_name in dpkg-deb dpkg-scanpackages gpg gpgv sha256sum sha512sum
+do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'APT exact signing-subkey test skipped (%s unavailable)\n' \
+      "$command_name"
+    exit 0
+  fi
+done
+
+PACKAGE=$(bash "$REPO_ROOT/packaging/debian/build-deb.sh" "$TMP_ROOT/package")
+REPOSITORY="$TMP_ROOT/repository"
+SOURCE_DATE_EPOCH=1787875200 \
+  bash "$REPO_ROOT/packaging/debian/build-apt-repository.sh" \
+    "$REPOSITORY" "$PACKAGE" >/dev/null
+
+GNUPGHOME="$TMP_ROOT/gnupg"
+export GNUPGHOME
+mkdir -m 0700 "$GNUPGHOME"
+
+PASSPHRASE='apt-exact-subkey-test'
+
+gpg --batch --pinentry-mode loopback \
+  --passphrase "$PASSPHRASE" \
+  --quick-generate-key \
+  'Pantheon Local Tools Rotation CI <ci@example.invalid>' \
+  rsa2048 cert 1d >/dev/null 2>&1
+
+PRIMARY_FINGERPRINT=$(
+  gpg --batch --with-colons --list-secret-keys |
+    awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+)
+[ -n "$PRIMARY_FINGERPRINT" ] || fail 'rotation-test primary fingerprint is missing'
+
+# Create two simultaneously usable signing subkeys. Exact selection must sign
+# with the requested one rather than whichever subkey GPG would choose itself.
+gpg --batch --pinentry-mode loopback \
+  --passphrase "$PASSPHRASE" \
+  --quick-add-key "$PRIMARY_FINGERPRINT" rsa2048 sign 1d >/dev/null 2>&1
+
+gpg --batch --pinentry-mode loopback \
+  --passphrase "$PASSPHRASE" \
+  --quick-add-key "$PRIMARY_FINGERPRINT" rsa2048 sign 1d >/dev/null 2>&1
+
+FIRST_SUBKEY=$(
+  gpg --batch --with-colons --list-secret-keys "$PRIMARY_FINGERPRINT" |
+    awk -F: '
+      $1 == "ssb" { want_fpr = 1; next }
+      want_fpr && $1 == "fpr" {
+        print $10
+        exit
+      }
+    '
+)
+
+SECOND_SUBKEY=$(
+  gpg --batch --with-colons --list-secret-keys "$PRIMARY_FINGERPRINT" |
+    awk -F: '
+      $1 == "ssb" { want_fpr = 1; next }
+      want_fpr && $1 == "fpr" {
+        seen++
+        if (seen == 2) {
+          print $10
+          exit
+        }
+        want_fpr = 0
+      }
+    '
+)
+
+[ -n "$FIRST_SUBKEY" ] || fail 'first signing subkey fingerprint is missing'
+[ -n "$SECOND_SUBKEY" ] || fail 'second signing subkey fingerprint is missing'
+[ "$FIRST_SUBKEY" != "$SECOND_SUBKEY" ] || fail 'signing subkeys are not distinct'
+
+PANTHEON_LOCAL_APT_SIGNING_PASSPHRASE="$PASSPHRASE" \
+PANTHEON_LOCAL_APT_EXACT_SIGNING_KEY=1 \
+  bash "$REPO_ROOT/packaging/debian/sign-apt-repository.sh" \
+    "$REPOSITORY" "$FIRST_SUBKEY" >/dev/null
+
+KEYRING="$REPOSITORY/pantheon-local-tools-archive-keyring.gpg"
+INRELEASE="$REPOSITORY/dists/stable/InRelease"
+
+PUBLISHED_PRIMARY=$(
+  gpg --batch --show-keys --with-colons "$KEYRING" |
+    awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+)
+assert_eq "$PUBLISHED_PRIMARY" "$PRIMARY_FINGERPRINT"
+
+PUBLISHED_SUBKEYS=$(
+  gpg --batch --show-keys --with-colons "$KEYRING" |
+    awk -F: '$1 == "sub" { count++ } END { print count + 0 }'
+)
+assert_eq "$PUBLISHED_SUBKEYS" '2'
+
+SIGNATURE_FINGERPRINT=$(
+  gpgv --status-fd 1 --keyring "$KEYRING" "$INRELEASE" 2>/dev/null |
+    awk '$2 == "VALIDSIG" && !found { print $3; found = 1 }'
+)
+assert_eq "$SIGNATURE_FINGERPRINT" "$FIRST_SUBKEY"
+
+if PANTHEON_LOCAL_APT_EXACT_SIGNING_KEY=invalid \
+  bash "$REPO_ROOT/packaging/debian/sign-apt-repository.sh" \
+    "$REPOSITORY" "$FIRST_SUBKEY" >/dev/null 2>&1
+then
+  fail 'signer accepted an invalid exact-signing-key mode'
+fi
+
+printf 'APT exact signing-subkey tests passed\n'


### PR DESCRIPTION
## Summary

Finish the public signed-APT client and recovery boundary for #36.

This PR:

- adds clean GitHub-hosted Ubuntu validation against the real public GitHub Pages APT repository;
- documents fingerprint-pinned `/etc/apt/keyrings` + deb822 `Signed-By` client setup;
- records the production trust model, signing-subkey rotation overlap, revocation, and recovery procedure;
- adds optional exact signing-subkey selection so future rotation never relies on GPG choosing among multiple usable subkeys implicitly; and
- adds regression coverage proving an explicitly selected signing subkey is the one that signs `InRelease` while the exported keyring retains the full primary identity and sibling subkeys.

The real public v0.1.0 WSL2 path is already complete: archive identity/signature verification, `apt update`, candidate discovery, install, config round-trip, reinstall with config preservation, uninstall, and package-file removal all passed. The certification-capable primary secret has been removed from the online WSL bootstrap state after verifying the encrypted offline recovery copy.

Refs #36 and #9. Real previous-version -> newer-version upgrade remains deferred to #30 because v0.1.0 is still the only published Debian package.