### PR TITLE
Update Pages actions to Node 24 releases

### DIFF
--- a/.github/workflows/publish-apt-repository.yml
+++ b/.github/workflows/publish-apt-repository.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload GitHub Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ${{ runner.temp }}/apt-repository
 
@@ -263,4 +263,4 @@ jobs:
     steps:
       - name: Deploy APT repository to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary

- update `actions/upload-pages-artifact` from v4 to the exact v5.0.0 commit
- update `actions/deploy-pages` from v4 to the exact v5.0.0 commit
- remove the Node.js 20 deprecation path observed during the successful production APT publication run

No APT repository logic, signing logic, release metadata, or client behavior changes.

This is final v0.1.0 publication-workflow hygiene; #24, #29, and #30 remain intentionally deferred follow-up validation.