### PR TITLE
Refresh repository documentation after v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable user-facing changes to Pantheon Local Tools are recorded here.
 
 The project follows Semantic Versioning for its public command/configuration contract. The repository-root `VERSION` file is canonical; tagged releases use the corresponding `vVERSION` Git tag.
 
+## Unreleased
+
+### Added
+
+- Published the current stable release through the public Homebrew tap at `zevarix/tap`.
+- Published a signed Debian/Ubuntu/WSL APT repository on GitHub Pages with dedicated `Signed-By` keyring trust, hosted-Ubuntu validation, and real WSL2 validation.
+- Added the public Pantheon Local Tools product homepage at the same GitHub Pages origin used by the signed APT repository.
+
+### Changed
+
+- Hardened APT publication around immutable release assets, reduced signing-subkey material, explicit rotation boundaries, deterministic repository assembly, and public-client validation.
+- Refreshed repository documentation after the first public release so the README acts as a concise project front door and deep implementation/release details remain in focused docs.
+- Generalized maintainer release and packaging documentation for future releases instead of leaving first-release-only instructions in durable runbooks.
+
+The current public CLI payload remains the v0.1.0 release; these entries describe post-tag distribution, publication, website, and documentation work on `main` unless a later release notes otherwise.
+
 ## 0.1.0 — 2026-08-27
 
 First public release of Pantheon Local Tools.

--- a/README.md
+++ b/README.md
@@ -2,55 +2,159 @@
 
 [![Validate](https://github.com/zevarix/pantheon-local-tools/actions/workflows/validate.yml/badge.svg?branch=main)](https://github.com/zevarix/pantheon-local-tools/actions/workflows/validate.yml)
 
-> **v0.1.0:** The first public release has completed its required real-provider and real-host validation. See [`CHANGELOG.md`](CHANGELOG.md) and [release readiness](https://github.com/zevarix/pantheon-local-tools/issues/7).
+**[Project website](https://zevarix.github.io/pantheon-local-tools/)** · [Latest release](https://github.com/zevarix/pantheon-local-tools/releases/latest) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md)
 
-Provider-neutral local development helpers for Pantheon workflows, with DDEV and Lando as the first supported local providers.
+Pantheon Local Tools is a free, open-source CLI for safer, repeatable Pantheon local-development workflows across **DDEV** and **Lando**.
 
-Pantheon Local Tools is built to make common Pantheon local-development tasks safer and more repeatable without hard-coding one developer's machine layout, employer, organization naming conventions, Pantheon Tags, local directory mappings, or local development stack.
+It is designed to replace machine-specific glue scripts without taking ownership away from Pantheon, Terminus, Git, or the local provider. The shared Pantheon/Terminus core stays provider-neutral, project-owned DDEV/Lando configuration remains authoritative, and ambiguous or destructive situations fail instead of guessing.
 
-The initial release was validated against Drupal projects. The shared Pantheon/Terminus core stays framework-neutral where doing so does not weaken safety or validation.
+The public release line has completed real-provider and real-host validation on macOS, Linux/hosted Ubuntu, and Windows through WSL2. See [`docs/real-integration-validation.md`](docs/real-integration-validation.md) for the evidence model and [`docs/compatibility.md`](docs/compatibility.md) for the supported `0.1.x` contract.
 
-## Commands
+## Quick start
 
-Implemented command surfaces are:
+### Prerequisites
+
+Install the tools required by the workflows you intend to use:
+
+- **Git** and **Bash**;
+- **Terminus**, authenticated before commands that query Pantheon; and
+- at least one supported local provider: **DDEV** or **Lando**.
+
+Pantheon remains authoritative for Terminus installation and authentication:
+
+- [Install and Update Terminus](https://docs.pantheon.io/terminus/install)
+- [Create and manage machine tokens](https://docs.pantheon.io/machine-tokens)
+
+Pantheon Local Tools does not store Pantheon machine tokens.
+
+### Install
+
+#### macOS with Homebrew
+
+```bash
+brew install zevarix/tap/pantheon-local-tools
+```
+
+#### Debian, Ubuntu, or WSL
+
+First complete the one-time fingerprint-verifying repository setup in [`docs/apt-repository.md`](docs/apt-repository.md). After that:
+
+```bash
+sudo apt-get update
+sudo apt-get install pantheon-local-tools
+```
+
+#### Portable clone install
+
+```bash
+git clone https://github.com/zevarix/pantheon-local-tools.git
+cd pantheon-local-tools
+./install.sh
+```
+
+The portable installer links `pantheon-local` into `~/.local/bin` by default and does not edit shell startup files. Set `PANTHEON_LOCAL_BIN_DIR` to choose another destination.
+
+Verify the installation with:
+
+```bash
+pantheon-local --version
+```
+
+### Configure and try a Multidev checkout
+
+Choose a checkout root and, optionally, a default provider:
 
 ```bash
 pantheon-local config set root ~/sites/pantheon
 pantheon-local config set provider ddev
-pantheon-local config get provider
-pantheon-local config tag set "Client Sites" clients
-pantheon-local config tag list
-pantheon-local config list
+```
+
+Resolve a real existing Pantheon Multidev without changing the filesystem:
+
+```bash
+pantheon-local multidev SITE.ENV --dry-run
+```
+
+When the plan is correct, create the isolated local checkout:
+
+```bash
+pantheon-local multidev SITE.ENV --provider ddev --start
+```
+
+Use `lando` instead of `ddev` when that is the project/provider you want.
+
+## Commands
+
+```text
 pantheon-local config path
+pantheon-local config get KEY
+pantheon-local config set KEY VALUE
+pantheon-local config unset KEY
+pantheon-local config list
+pantheon-local config tag get TAG
+pantheon-local config tag set TAG DIRECTORY
+pantheon-local config tag unset TAG
+pantheon-local config tag list
 
 pantheon-local multidev SITE.ENV
-pantheon-local multidev SITE.ENV --dry-run
-pantheon-local multidev SITE.ENV --provider lando --group migration
-pantheon-local multidev SITE.ENV --provider ddev --start
+  --provider ddev|lando
+  --group NAME
+  --dry-run
+  --start
 
-pantheon-local pull live
-pantheon-local pull test --database-only
-pantheon-local pull live --files-only
-pantheon-local pull feature-a --provider lando
+pantheon-local pull ENV
+  --database-only
+  --files-only
+  --provider ddev|lando
 
 pantheon-local status
 pantheon-local version
 pantheon-local --version
 ```
 
-Convenience wrapper commands may be added after the canonical `pantheon-local` interface is stable.
+## Core workflows
+
+### Multidev checkouts
+
+`pantheon-local multidev SITE.ENV` clones an **existing** Pantheon Multidev into an isolated local checkout. It does not create, delete, or mutate the remote Pantheon environment.
+
+The command resolves the authoritative Git URL through Terminus, applies user-configured Pantheon Tag routing when present, refuses occupied destinations, configures the selected local provider additively, and finalizes the checkout only after local setup succeeds. `--dry-run` resolves and prints the plan without cloning; `--start` is explicit.
+
+See [`docs/multidev.md`](docs/multidev.md) for the full workflow and safety contract.
+
+### Data pulls
+
+`pantheon-local pull ENV` refreshes local Pantheon data while protecting checked-out Git code.
+
+```bash
+pantheon-local pull live
+pantheon-local pull test --database-only
+pantheon-local pull live --files-only
+```
+
+Provider-specific transfer stays delegated to DDEV or Lando. Before and after the provider operation, Pantheon Local Tools verifies that Git `HEAD` and tracked content are unchanged. Database/files provenance is recorded only after provider success and Git-integrity verification.
+
+See [`docs/pull.md`](docs/pull.md) for component selection, provider behavior, and the complete pull safety contract.
+
+### Local status
+
+`pantheon-local status` is a local, read-only inspection command. It can run from the checkout root or a subdirectory and does not contact Pantheon or start/rebuild a provider.
+
+For managed checkouts it reports recorded Pantheon identity, provider, Git state, provider-derived runtime URL when available, and independent database/files provenance. Existing DDEV/Lando Git checkouts are also supported; unavailable Pantheon metadata is reported as not recorded rather than guessed.
+
+See [`docs/status.md`](docs/status.md) for the status contract.
 
 ## Configuration
 
-Users do not need to hand-edit configuration files. `pantheon-local config` reads and writes a Git-compatible configuration file through Git's own parser.
+User configuration is managed through `pantheon-local config`; hand-editing is not required.
 
-By default the file is stored at:
+By default it lives at:
 
 ```text
 ~/.config/pantheon-local-tools/config
 ```
 
-If `XDG_CONFIG_HOME` is set, that location is respected. `PANTHEON_LOCAL_CONFIG` can override the complete path for automation and testing.
+`XDG_CONFIG_HOME` is respected. `PANTHEON_LOCAL_CONFIG` can override the complete path for automation and testing.
 
 Built-in defaults are:
 
@@ -63,237 +167,62 @@ Examples:
 ```bash
 pantheon-local config set root ~/work/pantheon
 pantheon-local config set provider lando
-pantheon-local config tag set "Internal" internal
-pantheon-local config tag unset "Internal"
-pantheon-local config unset provider
+pantheon-local config tag set "Client Sites" clients
+pantheon-local config list
 ```
 
-`config unset` removes the stored value and restores the built-in default where one exists. `config.example` documents the underlying file format, but the CLI is the recommended interface.
+Organization-specific Pantheon Tags, directory names, account details, and machine paths belong only in user configuration and are never project defaults.
 
-Organization-specific Pantheon Tags and local directory names belong only in user configuration and are never project defaults.
+## Providers and hosts
 
-## Multidev checkouts
+Supported local providers for the `0.1.x` line are **DDEV** and **Lando**.
 
-`pantheon-local multidev SITE.ENV` clones an **existing** Pantheon multidev environment into an isolated local checkout. It does not create, delete, or mutate the remote Pantheon environment.
+Pantheon Local Tools preserves project-owned `.ddev/config.yaml`, `.lando.yml`, services, add-ons, custom tooling, and Compose extensions. Local overrides are additive; if a change cannot be made safely, the tool fails instead of replacing provider configuration.
 
-The command:
-
-1. verifies Terminus authentication;
-2. resolves user-configured Pantheon Tag routing;
-3. gets the authoritative Git URL from Terminus;
-4. refuses to overwrite an existing destination;
-5. clones into a temporary sibling checkout;
-6. selects DDEV or Lando explicitly/configurably, failing on ambiguity;
-7. writes only local provider overrides and records local state under `.git/`; and
-8. finalizes the checkout only after local configuration succeeds.
-
-`--dry-run` performs the read-only Pantheon lookups and prints the resolved plan without cloning or creating directories. `--start` is explicit; the tool never silently starts or rebuilds a local runtime.
-
-With no configured Pantheon Tag routes, checkouts live below:
-
-```text
-<root>/multidev/<site>-<env>
-```
-
-With a Tag route such as `Client Sites -> clients`, the same checkout lives below:
-
-```text
-<root>/clients/multidev/<site>-<env>
-```
-
-Optional grouping adds one safe path segment:
-
-```bash
-pantheon-local multidev SITE.ENV --group migration
-```
-
-See [`docs/multidev.md`](docs/multidev.md) for the full safety and provider behavior contract.
-
-## Data pulls
-
-`pantheon-local pull ENV` refreshes local Pantheon data from one explicitly named environment while preserving the checkout's Git code.
-
-By default both database and files are refreshed. Component-specific workflows are explicit:
-
-```bash
-pantheon-local pull live --database-only
-pantheon-local pull live --files-only
-```
-
-This is useful for Drupal workflows such as refreshing only the database before `drush updb` and `drush cex`, where synchronizing files would add time without helping the change being developed.
-
-The command uses the provider already associated with the checkout. If no provider has been recorded, it detects an unambiguous `.lando.yml` or `.ddev/config.yaml`; ambiguous checkouts require `--provider ddev|lando`.
-
-For Lando, the adapter delegates to the Pantheon recipe with explicit sources and always disables code pulls. For example, database-only becomes:
-
-```text
-lando pull --code=none --database=ENV --files=none
-```
-
-For DDEV, the adapter delegates to DDEV's Pantheon provider with a one-time environment override and maps component selection to DDEV's `--skip-files` / `--skip-db` flags rather than rewriting project configuration.
-
-Pantheon Local Tools does not collect provider machine tokens. Lando/DDEV own their supported Pantheon authentication workflows.
-
-Before and after the provider pull, the tool verifies that Git `HEAD` and all tracked content are unchanged. Only after provider success and that verification does it update component-specific provenance for `pantheon-local status`.
-
-See [`docs/pull.md`](docs/pull.md) for the complete pull safety contract and provider details.
-
-## Local checkout status
-
-`pantheon-local status` is a local, read-only inspection command. It can be run from the checkout root or any subdirectory and does not contact Pantheon or start/rebuild a provider.
-
-For checkouts created by Pantheon Local Tools it reports recorded Pantheon metadata together with current Git state and independent database/files provenance. When provider runtime metadata is safely available, the provider's actual application URL takes precedence over a recorded fallback:
-
-```text
-Pantheon Local Tools status
-
-Directory:       /home/example/sites/clients/multidev/example-site-feature-a
-Managed:         yes
-Pantheon:        example-site.feature-a
-Tag:             Client Sites
-Provider:        lando
-Provider config: present
-Local name:      example-site-feature-a
-Local URL:       https://example-site-feature-a.example.test
-URL source:      provider runtime
-Git branch:      feature-a
-Git tracking:    origin/feature-a
-Git state:       clean
-Database source: test
-Files source:    live
-```
-
-Existing Git checkouts are also supported. When no Pantheon Local Tools state exists, status detects an unambiguous DDEV/Lando project configuration and shows unavailable Pantheon-specific metadata as `(not recorded)` rather than guessing.
-
-URL discovery is best-effort and read-only: Lando is inspected through `lando info`, while DDEV exposes its `primary_url` through `ddev describe -j`. The tool does not assume a universal `lndo.site` or `ddev.site` suffix and never starts or rewrites a provider just to obtain a URL. If runtime discovery is unavailable, status falls back to recorded local metadata.
-
-Database/files sources are written only after successful `pantheon-local pull` operations; they are never inferred from the Git branch.
-
-See [`docs/status.md`](docs/status.md) for the complete status contract.
-
-## Terminus prerequisite
-
-Pantheon Local Tools expects Terminus to already be installed and authenticated before commands directly query Pantheon. The tool detects missing authentication and fails with an actionable message rather than attempting to manage Pantheon credentials itself.
-
-Pantheon's official documentation covers both installation and authentication:
-
-- [Install and Update Terminus](https://docs.pantheon.io/terminus/install)
-- [Create and manage machine tokens](https://docs.pantheon.io/machine-tokens)
-- [`terminus auth:login` command reference](https://docs.pantheon.io/terminus/commands/auth-login)
-
-A new Terminus installation generally needs a Pantheon machine token for its first authentication. Follow Pantheon's current instructions rather than storing a token in Pantheon Local Tools configuration. After authentication, `terminus auth:whoami` is a useful way to verify the active Pantheon identity.
-
-Provider-delegated commands such as `pull` use the provider's supported authentication boundary instead of copying tokens into Pantheon Local Tools.
-
-## Local development providers
-
-The first supported providers are **DDEV** and **Lando**.
-
-Drupal.org recommends DDEV for Drupal local development, while existing Pantheon projects may use either DDEV or Lando. Pantheon Local Tools therefore keeps Pantheon and Terminus behavior in a shared core and delegates local-runtime behavior to provider-specific code.
-
-For multidev creation, provider selection follows the explicit option, configured default, then safe auto-detection after clone. For commands operating on an existing checkout such as `pull`, recorded checkout state or the checkout's actual provider configuration takes precedence over the global default.
-
-For multidev, DDEV requires an existing `.ddev/config.yaml` and receives a local `.ddev/config.local.yaml` name override. Lando requires an existing `.lando.yml` and receives a local `.lando.local.yml` isolation override.
-
-Pantheon Local Tools is additive around provider-owned project configuration. It does not replace `.lando.yml` or `.ddev/config.yaml`, and it must preserve existing services/tooling/add-ons such as phpMyAdmin, Redis, Solr, MailHog, custom Lando tooling, DDEV extra hostnames, and `docker-compose.*.yaml` services. If a local override cannot be changed safely, the tool must fail rather than clobber it.
-
-Generated provider overrides are added to the checkout's `.git/info/exclude`; the project's shared `.gitignore` is not modified.
-
-See [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) for the provider boundary and upstream references.
-
-## Supported host environments
-
-The command-line tooling targets:
+Supported host environments are:
 
 - macOS;
 - Linux; and
 - Windows through WSL/WSL2.
 
-On Windows, commands run inside the WSL Linux environment and use Linux paths. Native PowerShell and Command Prompt are not initial targets. The selected local provider must also be installed in a supported configuration for that host environment.
+On Windows, commands run inside WSL using Linux paths. Native PowerShell and Command Prompt are not initial targets.
 
-The shipped shell code intentionally avoids Bash 4-only features so it remains compatible with the older Bash supplied by macOS as well as modern Bash on Linux and WSL.
+See [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) for provider boundaries and upstream references.
 
-## Versioning and compatibility
+## Safety contract
 
-The repository-root `VERSION` file is the canonical project version. Development snapshots use a SemVer prerelease such as `0.1.0-dev`; a tagged release contains the exact release version and uses the corresponding `vVERSION` Git tag.
+Pantheon Local Tools is intentionally conservative around developer machines and remote environments:
 
-Check the installed version with either:
+- existing checkout destinations are never silently overwritten;
+- local checkout creation never creates or deletes a remote Pantheon Multidev;
+- `pantheon-local pull` never pulls Git code;
+- provider/project configuration remains provider-owned;
+- provider detection and Pantheon Tag routing fail on ambiguity rather than guessing;
+- provider start/rebuild behavior is explicit;
+- Pantheon machine tokens are not collected or persisted;
+- pull provenance is recorded only after provider success and Git-integrity verification; and
+- package installation/removal does not own user configuration or checkout-local state.
 
-```bash
-pantheon-local version
-pantheon-local --version
-```
+The complete compatibility and safety guarantees for the `0.1.x` line are in [`docs/compatibility.md`](docs/compatibility.md).
 
-The documented command/configuration and safety guarantees for the `0.1.x` line are defined in [`docs/compatibility.md`](docs/compatibility.md). Patch releases should preserve that contract; intentionally breaking pre-1.0 changes belong in a future minor release with release notes/migration guidance.
+## Distribution
 
-See [`CHANGELOG.md`](CHANGELOG.md) for user-visible changes and validation notes.
+Pantheon Local Tools ships through several equivalent distribution paths built from the same tagged project contents:
 
-## Installation and distribution
+- the portable clone installer;
+- [Homebrew](packaging/homebrew/README.md) through `zevarix/tap`;
+- downloadable architecture-independent `.deb` release artifacts; and
+- the [signed APT repository](docs/apt-repository.md) for Debian, Ubuntu, and WSL.
 
-### Install from a clone
+The **[project website](https://zevarix.github.io/pantheon-local-tools/)** and signed APT repository intentionally share one GitHub Pages origin. Humans get the product page at `/`; APT consumes the signed repository metadata and package indexes beneath that same origin.
 
-The clone installer is the supported portable installation path and package-manager fallback:
-
-```bash
-git clone git@github.com:zevarix/pantheon-local-tools.git
-cd pantheon-local-tools
-./install.sh
-```
-
-The installer creates a symlink at `~/.local/bin/pantheon-local` by default and refuses to overwrite an unrelated existing command. Set `PANTHEON_LOCAL_BIN_DIR` to choose a different destination. It does not edit shell startup files.
-
-### Homebrew
-
-The Homebrew formula path is implemented and exercised by macOS CI through a real temporary tap. The v0.1.0 release publishes the intended end-user install path:
-
-```bash
-brew install zevarix/tap/pantheon-local-tools
-```
-
-The publishable formula is generated only from the immutable release source artifact URL and verified SHA256. See [`packaging/homebrew/README.md`](packaging/homebrew/README.md).
-
-### Debian / Ubuntu / WSL
-
-The v0.1.0 Debian package is published both as a downloadable release artifact and through the signed APT repository:
-
-```text
-https://zevarix.github.io/pantheon-local-tools
-```
-
-The repository uses a dedicated `/etc/apt/keyrings` keyring and deb822 `Signed-By` source. Because the archive key is a trust anchor, follow the fingerprint-verifying installation procedure in [`docs/apt-repository.md`](docs/apt-repository.md) rather than piping an unverified key directly into APT.
-
-After the repository is configured, installation is the normal APT path:
-
-```bash
-sudo apt-get update
-sudo apt-get install pantheon-local-tools
-```
-
-The public v0.1.0 repository path has completed real WSL2 validation and clean GitHub-hosted Ubuntu validation, including archive fingerprint/signature verification, `apt update`, candidate discovery, install, CLI/config checks, reinstall with configuration preservation, and uninstall. A real previous-version to newer-version upgrade remains deferred to #30 because v0.1.0 is the first published Debian package.
-
-The architecture-independent package builder remains available to maintainers and contributors:
-
-```bash
-bash packaging/debian/build-deb.sh
-```
-
-A downloaded GitHub Release package can also be installed directly:
-
-```bash
-sudo apt install ./pantheon-local-tools_<VERSION>_all.deb
-```
-
-The package installs application files under `/usr/lib/pantheon-local-tools`, exposes `/usr/bin/pantheon-local`, and leaves user configuration/checkouts outside package ownership. See [`packaging/debian/README.md`](packaging/debian/README.md) for package/repository implementation details.
-
-The clone installer remains supported as the portable fallback for macOS, Linux, WSL, contributors, and CI even after package-manager distribution is published.
-
-Maintainers should follow [`docs/releasing.md`](docs/releasing.md) for the tag, deterministic source archive, checksums, GitHub Release, Homebrew formula, Debian artifact, and signed APT publication sequence. Real provider/host release gates are in [`docs/real-integration-validation.md`](docs/real-integration-validation.md).
+Release artifacts and package metadata are tied to immutable tagged releases. See [`docs/releasing.md`](docs/releasing.md) for the maintainer procedure.
 
 ## Development
 
-The installed `bin/pantheon-local` command is a small dispatcher. Command implementations live under `libexec/`, which keeps workflow slices independently testable while preserving one public CLI.
+The installed `bin/pantheon-local` command is a small dispatcher. Command implementations live under `libexec/`, keeping workflow slices independently testable while preserving one public CLI.
 
-Run the test suite directly:
+Run the integration suite with:
 
 ```bash
 for test in tests/test-*.sh; do
@@ -307,7 +236,18 @@ Run ShellCheck when available:
 shellcheck bin/pantheon-local libexec/pantheon-local-* install.sh tests/test-*.sh packaging/debian/*.sh packaging/homebrew/*.sh packaging/release/*.sh
 ```
 
-CI runs syntax validation, ShellCheck, and the full shell integration suite on both Ubuntu and macOS. The suite includes isolated-home installer coverage, provider mocks, deterministic release-source packaging, Ubuntu `.deb` layout validation, signed APT repository generation/signing checks, and macOS Homebrew temporary-tap installation. Real WSL2 fresh-clone/install/full-suite validation is also complete for v0.1.0, and the published APT repository has its own clean hosted-Ubuntu smoke workflow.
+CI runs syntax validation, ShellCheck, and the shell integration suite on Ubuntu and macOS. The project intentionally avoids Bash 4-only features so the shipped shell code remains compatible with the older Bash supplied by macOS as well as modern Bash on Linux and WSL.
+
+## Documentation
+
+- [`docs/multidev.md`](docs/multidev.md) — Multidev checkout behavior and safety
+- [`docs/pull.md`](docs/pull.md) — database/files pull behavior and Git protection
+- [`docs/status.md`](docs/status.md) — read-only checkout inspection contract
+- [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) — DDEV/Lando boundary and provider architecture
+- [`docs/compatibility.md`](docs/compatibility.md) — supported `0.1.x` public contract
+- [`docs/apt-repository.md`](docs/apt-repository.md) — signed APT client trust, rotation, and recovery
+- [`docs/real-integration-validation.md`](docs/real-integration-validation.md) — real-host/provider validation runbook
+- [`docs/releasing.md`](docs/releasing.md) — maintainer release procedure
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,10 +14,14 @@ Helpful reports include:
 - a minimal proof of concept when safe to provide; and
 - any suggested mitigation.
 
-Please avoid including real access tokens, passwords, SSH keys, database credentials, or other secrets in a report.
+Please avoid including real access tokens, passwords, SSH keys, database credentials, signing-key material, or other secrets in a report.
+
+## Supported versions
+
+The current `0.1.x` release line receives security fixes. Users should install the newest available `0.1.x` release rather than relying on an older patch release.
+
+The `main` branch is the development source and may contain changes that have not yet been released. Older pre-release snapshots are not supported as security-maintenance targets.
 
 ## Scope
 
-Security-sensitive areas include command injection, unsafe path handling, accidental overwrites, credential exposure, unintended remote writes, privilege escalation, and execution of untrusted contributor code.
-
-Supported-version information will be added after the first release.
+Security-sensitive areas include command injection, unsafe path handling, accidental overwrites, credential exposure, unintended remote writes, privilege escalation, execution of untrusted contributor code, and compromise of package or signed-repository distribution paths.

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -1,10 +1,12 @@
 # Signed APT repository
 
-Pantheon Local Tools publishes a signed Debian/Ubuntu/WSL repository at:
+Pantheon Local Tools publishes its project website and signed Debian/Ubuntu/WSL repository from the same GitHub Pages origin:
 
 ```text
-https://zevarix.github.io/pantheon-local-tools
+https://zevarix.github.io/pantheon-local-tools/
 ```
+
+The root URL is the human-facing product page. APT clients consume signed metadata, package indexes, the public archive keyring, and package files beneath that same origin.
 
 The repository uses the `stable` suite and `main` component. Client trust is scoped to a dedicated keyring through APT's `Signed-By` mechanism; `apt-key` is not used.
 
@@ -133,6 +135,8 @@ Never place a private primary key, private signing subkey, passphrase, decrypted
 
 ## Validation status
 
-The initial v0.1.0 repository has been published through GitHub Pages with signed `InRelease`/`Release.gpg` metadata. The public WSL2 path has been exercised through `apt update`, candidate discovery, install, CLI/config verification, reinstall with configuration preservation, uninstall, and package-file removal. `.github/workflows/validate-published-apt.yml` provides the corresponding clean GitHub-hosted Ubuntu validation against the public URL.
+The initial v0.1.0 repository was published through GitHub Pages with signed `InRelease`/`Release.gpg` metadata. The public WSL2 path was exercised through `apt update`, candidate discovery, install, CLI/config verification, reinstall with configuration preservation, uninstall, and package-file removal. `.github/workflows/validate-published-apt.yml` provides the corresponding clean GitHub-hosted Ubuntu validation against the public URL.
+
+The product homepage is deployed as part of the same static Pages artifact without changing APT's signed metadata or trust path.
 
 A real previous-version to newer-version upgrade remains deferred until a second stable Debian package has actually been published.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -110,7 +110,7 @@ Exact non-zero numeric exit codes are not part of the `0.1.x` contract; success 
 
 ## Packaging contract
 
-Homebrew, Debian packages, the clone installer, and any future signed APT repository must package the same tagged project contents and report the same `VERSION`.
+Homebrew, Debian packages, the signed APT repository, and the clone installer must package the same tagged project contents and report the same `VERSION`.
 
 Package installation/uninstallation must not:
 
@@ -118,6 +118,8 @@ Package installation/uninstallation must not:
 - rewrite user project files or provider configuration;
 - delete the user's Pantheon Local Tools configuration; or
 - delete checkout-local metadata inside user repositories.
+
+The project website may be published alongside machine-consumed package metadata on the same static origin, but presentation changes must not weaken package trust, mutate historical release artifacts, or change the package/version contract.
 
 ## Breaking changes
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,11 +18,14 @@ Do not tag first and hope to repair the release afterward. Prepare the release v
 
 ## 1. Prepare the release commit
 
-For `v0.1.0`, update the repository-root `VERSION` from the development value to:
+Set the repository-root `VERSION` to the exact version being released. For example:
 
-```text
-0.1.0
+```bash
+RELEASE_VERSION='<VERSION>'
+printf '%s\n' "$RELEASE_VERSION" > VERSION
 ```
+
+The value must be a release version such as `0.1.1`, not a development suffix such as `0.1.1-dev`.
 
 Run the full repository validation matrix and merge only when required checks pass.
 
@@ -91,7 +94,7 @@ After upload, download the published artifacts again and verify their SHA256 val
 
 ## 5. Publish the Homebrew formula
 
-The public tap is intended to be:
+The public tap repository is:
 
 ```text
 zevarix/homebrew-tap
@@ -106,7 +109,7 @@ zevarix/tap
 Use the exact published release source asset URL and its verified SHA256 to render the formula:
 
 ```bash
-VERSION=0.1.0
+VERSION=$(cat VERSION)
 URL="https://github.com/zevarix/pantheon-local-tools/releases/download/v${VERSION}/pantheon-local-tools-${VERSION}.tar.gz"
 SHA256="<verified published source artifact sha256>"
 
@@ -145,17 +148,19 @@ Verify user configuration remains outside package ownership and survives package
 
 Before advertising upgrade support, exercise a real previous-version -> current-version package upgrade. WSL/WSL2 requires its own real validation pass; Ubuntu CI is useful contract evidence but is not a substitute for WSL runtime proof.
 
-The signed hosted APT repository is published separately from the downloadable `.deb` at:
+The project website and signed hosted APT repository share this GitHub Pages origin:
 
 ```text
-https://zevarix.github.io/pantheon-local-tools
+https://zevarix.github.io/pantheon-local-tools/
 ```
+
+The root serves the human-facing product page while APT consumes the signed repository files beneath the same origin.
 
 `.github/workflows/publish-apt-repository.yml` assembles every stable published Debian package up to the target version, verifies each against its release `SHA256SUMS`, signs the resulting multiversion repository, validates it with an isolated APT client, and deploys the static tree to GitHub Pages. Pull requests exercise the same assembly/sign/validation path against the latest already-published stable release with an ephemeral key, but never deploy.
 
 Production APT publication uses the passphrase-protected signing-subkey material stored in the dedicated Actions secrets. The certification-capable primary key stays offline. When the optional `APT_SIGNING_SUBKEY_FINGERPRINT` secret is configured, publication forces GPG to use that exact imported signing subkey; use this during rotation overlap rather than relying on implicit GPG subkey selection.
 
-Stable non-prerelease GitHub Release publication triggers the APT publication workflow automatically. A manual workflow dispatch can bootstrap or republish an existing stable version without rebuilding historical package artifacts.
+Stable non-prerelease GitHub Release publication triggers the APT publication workflow automatically. A manual workflow dispatch can bootstrap or republish an existing stable version without rebuilding historical package artifacts. Changes on `main` limited to the static landing-page sources also republish the latest stable repository tree so website maintenance does not require a fake software release.
 
 After each APT publication, verify the real public path with `.github/workflows/validate-published-apt.yml` and, for release gates that require it, a WSL2 client. The clean hosted-Ubuntu workflow verifies the pinned archive fingerprint, `apt update`, candidate discovery, package installation, CLI/config behavior, reinstall with user-configuration preservation, and uninstall.
 
@@ -174,6 +179,7 @@ After publication, verify:
 - signed APT repository fingerprint/signature and package discovery when Debian distribution is enabled;
 - clean hosted-Ubuntu APT install/reinstall/uninstall through the public HTTPS repository;
 - required WSL2 APT validation through the same public repository;
+- the GitHub Pages root serves the product homepage rather than a 404, and its install/docs links point at the current maintained procedures;
 - configuration remains user-owned;
 - no provider/project state is created merely by package installation; and
 - the portable clone installer remains documented and functional.

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -36,7 +36,7 @@ and provides the command through a relative symlink:
 /usr/bin/pantheon-local -> ../lib/pantheon-local-tools/bin/pantheon-local
 ```
 
-Keeping `bin/`, `libexec/`, and `VERSION` together preserves the same relative module/version resolution used by the clone installer and future Homebrew formula.
+Keeping `bin/`, `libexec/`, and `VERSION` together preserves the same relative module/version resolution used by the clone installer and Homebrew formula.
 
 ## Install a downloaded package
 
@@ -71,11 +71,13 @@ Package removal does not own that file and therefore must not delete it. Checkou
 
 ## Signed APT repository
 
-The hosted APT repository is a separate distribution layer from the downloadable `.deb` and is published at:
+The project website and hosted APT repository are separate concerns published from the same GitHub Pages origin:
 
 ```text
-https://zevarix.github.io/pantheon-local-tools
+https://zevarix.github.io/pantheon-local-tools/
 ```
+
+The root is the human-facing product page. APT consumes the signed repository files beneath that same origin.
 
 End-user key verification, `/etc/apt/keyrings` installation, deb822 `Signed-By` setup, removal, signing-key rotation, revocation, and recovery procedures are documented in [`docs/apt-repository.md`](../../docs/apt-repository.md).
 
@@ -146,6 +148,8 @@ For every stable release up to and including the target version, the assembler:
 
 When `SOURCE_DATE_EPOCH` is not supplied, the target GitHub Release publication time is used so repeated assembly of the same target produces stable unsigned repository metadata.
 
+The assembler also copies the checked-in static product-page HTML/CSS into the Pages artifact. Those presentation files are outside APT's signed package metadata and do not replace or rewrite historical release artifacts.
+
 ### Sign repository metadata
 
 Signing is intentionally separate from repository generation:
@@ -192,8 +196,10 @@ Do not install the keyring without verifying the documented primary fingerprint 
 
 `.github/workflows/publish-apt-repository.yml` performs a real publication dry run on relevant pull requests with an ephemeral key against the latest already-published stable release. Stable release events and manual dispatches use the configured production signing-subkey secrets, upload the generated static archive as a GitHub Pages artifact, and deploy it through the `github-pages` environment.
 
-GitHub Pages is enabled with **Source: GitHub Actions**, and the initial v0.1.0 repository has been published and signature-verified through the real public URL. The workflow intentionally assembles historical `.deb` files from their published GitHub Release assets rather than rebuilding old packages.
+Changes on `main` limited to the checked-in landing-page HTML/CSS also republish the latest stable repository tree. This allows normal website maintenance without creating a fake software release while keeping unrelated APT infrastructure changes behind their explicit publication boundary.
 
-`.github/workflows/validate-published-apt.yml` exercises the public HTTPS repository on clean hosted Ubuntu, including archive fingerprint verification, `apt update`, candidate discovery, install, reinstall with user-configuration preservation, and uninstall. The same public v0.1.0 path has also completed real WSL2 validation.
+GitHub Pages is enabled with **Source: GitHub Actions**, and the initial v0.1.0 repository was published and signature-verified through the real public URL. The workflow intentionally assembles historical `.deb` files from their published GitHub Release assets rather than rebuilding old packages.
+
+`.github/workflows/validate-published-apt.yml` exercises the public HTTPS repository on clean hosted Ubuntu, including archive fingerprint verification, `apt update`, candidate discovery, install, reinstall with user-configuration preservation, and uninstall. The same public v0.1.0 path also completed real WSL2 validation.
 
 The first real previous-version to newer-version package upgrade remains deferred until a second published Debian package exists.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 Pantheon Local Tools is published through a small external Homebrew tap using immutable tagged release artifacts.
 
-The intended tap repository is:
+The public tap repository is:
 
 ```text
 zevarix/homebrew-tap
 ```
 
-Homebrew maps that GitHub repository to the short tap name `zevarix/tap`. The formula should live at:
+Homebrew maps that GitHub repository to the short tap name `zevarix/tap`. The formula lives at:
 
 ```text
 Formula/pantheon-local-tools.rb
@@ -59,10 +59,10 @@ bash packaging/homebrew/render-formula.sh VERSION URL SHA256 OUTPUT
 
 For a release, `VERSION` must equal the repository-root `VERSION` and the `vVERSION` Git tag. `URL` should be the uploaded deterministic GitHub Release source asset URL and `SHA256` must match that exact published asset. Do not use GitHub's automatically generated tag archive for release formula metadata.
 
-Example shape after `v0.1.0` exists:
+Example for the tagged release currently checked out:
 
 ```bash
-VERSION=0.1.0
+VERSION=$(cat VERSION)
 URL="https://github.com/zevarix/pantheon-local-tools/releases/download/v${VERSION}/pantheon-local-tools-${VERSION}.tar.gz"
 SHA256="<verified uploaded release source asset sha256>"
 bash packaging/homebrew/render-formula.sh \


### PR DESCRIPTION
## Summary

Repository-wide documentation pass after the first public release, signed APT publication, Homebrew publication, and launch of the GitHub Pages product site.

- makes the project website a first-class README entry point;
- shortens the README into a useful repo front door with quick start, command map, safety, distribution, and focused-doc links;
- distinguishes the human product homepage from the signed APT repository that shares the same Pages origin;
- updates APT/Debian/Homebrew docs from planned/future wording to the current published state;
- generalizes the release procedure so it remains useful for future releases instead of being tied to v0.1.0 preparation;
- updates the compatibility contract now that signed APT distribution exists;
- documents the supported 0.1.x security line and signed-distribution security scope.

Historical v0.1.0 validation evidence is intentionally retained where it is still factual.