### PR TITLE
Suppress harmless APT architecture warning

### DIFF
--- a/.github/workflows/validate-published-apt.yml
+++ b/.github/workflows/validate-published-apt.yml
@@ -95,6 +95,7 @@ jobs:
           URIs: $APT_REPOSITORY_URL
           Suites: stable
           Components: main
+          Architectures: all
           Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
           EOF
 
@@ -102,7 +103,14 @@ jobs:
             "$RUNNER_TEMP/pantheon-local-tools.sources" \
             /etc/apt/sources.list.d/pantheon-local-tools.sources
 
-          sudo apt-get update
+          apt_output=$(sudo apt-get update 2>&1)
+          printf '%s\n' "$apt_output"
+          case "$apt_output" in
+            *"doesn't support architecture"*)
+              echo 'APT emitted an unsupported-architecture notice' >&2
+              exit 1
+              ;;
+          esac
 
           candidate=$(
             apt-cache policy pantheon-local-tools |
@@ -191,7 +199,16 @@ jobs:
 
       - name: Install through the one-command APT bootstrap
         shell: bash
-        run: bash ./install-apt.sh
+        run: |
+          set -euo pipefail
+          install_output=$(bash ./install-apt.sh 2>&1)
+          printf '%s\n' "$install_output"
+          case "$install_output" in
+            *"doesn't support architecture"*)
+              echo 'one-command install emitted an unsupported-architecture notice' >&2
+              exit 1
+              ;;
+          esac
 
       - name: Verify bootstrap result
         shell: bash
@@ -200,6 +217,9 @@ jobs:
 
           [ -r /etc/apt/keyrings/pantheon-local-tools.gpg ]
           [ -r /etc/apt/sources.list.d/pantheon-local-tools.sources ]
+          grep -Fq \
+            'Architectures: all' \
+            /etc/apt/sources.list.d/pantheon-local-tools.sources
           grep -Fq \
             'Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg' \
             /etc/apt/sources.list.d/pantheon-local-tools.sources

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -8,7 +8,7 @@ https://zevarix.github.io/pantheon-local-tools/
 
 The root URL is the human-facing product page. APT clients consume signed metadata, package indexes, the public archive keyring, and package files beneath that same origin.
 
-The repository uses the `stable` suite and `main` component. Client trust is scoped to a dedicated keyring through APT's `Signed-By` mechanism; `apt-key` is not used.
+The repository uses the `stable` suite and `main` component. Client trust is scoped to a dedicated keyring through APT's `Signed-By` mechanism; `apt-key` is not used. The package is architecture-independent (`Architecture: all`), so the client source explicitly requests only the published `binary-all` index instead of probing for host-specific indexes such as `binary-amd64`.
 
 ## Quick install
 
@@ -77,6 +77,7 @@ Types: deb
 URIs: https://zevarix.github.io/pantheon-local-tools
 Suites: stable
 Components: main
+Architectures: all
 Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
 EOF
 
@@ -149,7 +150,7 @@ Never place a private primary key, private signing subkey, passphrase, decrypted
 
 ## Validation status
 
-The initial v0.1.0 repository was published through GitHub Pages with signed `InRelease`/`Release.gpg` metadata. The public WSL2 path was exercised through `apt update`, candidate discovery, install, CLI/config verification, reinstall with configuration preservation, uninstall, and package-file removal. `.github/workflows/validate-published-apt.yml` provides the corresponding clean GitHub-hosted Ubuntu validation against the public URL and now separately exercises the one-command bootstrap helper against that same public repository.
+The initial v0.1.0 repository was published through GitHub Pages with signed `InRelease`/`Release.gpg` metadata. The public WSL2 path was exercised through `apt update`, candidate discovery, install, CLI/config verification, reinstall with configuration preservation, uninstall, and package-file removal. `.github/workflows/validate-published-apt.yml` provides the corresponding clean GitHub-hosted Ubuntu validation against the public URL and separately exercises the one-command bootstrap helper against that same public repository. Both paths assert that the architecture-independent source does not emit a host-architecture mismatch notice.
 
 The product homepage is deployed as part of the same static Pages artifact without changing APT's signed metadata or trust path.
 

--- a/install-apt.sh
+++ b/install-apt.sh
@@ -69,6 +69,7 @@ Types: deb
 URIs: $APT_REPOSITORY_URL
 Suites: stable
 Components: main
+Architectures: all
 Signed-By: $APT_KEYRING_PATH
 EOF
 

--- a/tests/test-install-apt.sh
+++ b/tests/test-install-apt.sh
@@ -104,6 +104,7 @@ assert_file_contains "$CAPTURE_SOURCE" 'Types: deb'
 assert_file_contains "$CAPTURE_SOURCE" 'URIs: https://zevarix.github.io/pantheon-local-tools'
 assert_file_contains "$CAPTURE_SOURCE" 'Suites: stable'
 assert_file_contains "$CAPTURE_SOURCE" 'Components: main'
+assert_file_contains "$CAPTURE_SOURCE" 'Architectures: all'
 assert_file_contains "$CAPTURE_SOURCE" 'Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg'
 
 # A fingerprint mismatch must fail before any privileged write or APT action.


### PR DESCRIPTION
Closes #48.

## What changed
- scope the deb822 client source to `Architectures: all`, matching the repository's published `binary-all` index and package architecture;
- keep Release metadata truthful instead of inventing a host-specific index;
- update the manual APT setup to match the one-command bootstrap;
- extend deterministic installer tests to assert the architecture scope;
- make hosted public-repository validation fail if APT emits the unsupported-architecture notice;
- verify the one-command bootstrap writes the scoped source and remains installable.

The package remains `Architecture: all`; this only prevents APT on amd64/arm64 hosts from probing a repository index that is intentionally not published.