### PR TITLE
Add guided initial configuration

### DIFF
--- a/libexec/pantheon-local-core
+++ b/libexec/pantheon-local-core
@@ -11,6 +11,7 @@ PROVIDER_URL="$SCRIPT_DIR/pantheon-local-provider-url"
 usage() {
   cat <<'USAGE'
 Usage:
+  pantheon-local config init [--root PATH] [--provider auto|ddev|lando]
   pantheon-local config path
   pantheon-local config get KEY
   pantheon-local config set KEY VALUE
@@ -25,6 +26,9 @@ Usage:
 Configuration keys:
   root      Absolute local root for Pantheon checkouts.
   provider  auto, ddev, or lando.
+
+Run `pantheon-local config init` in a terminal for guided setup. Supply
+--root and/or --provider for a non-interactive one-command configuration.
 USAGE
 }
 
@@ -244,9 +248,135 @@ config_list() {
   done
 }
 
+config_init_summary() {
+  local root=$1 provider=$2
+  printf 'Configuration:\n'
+  printf '  Root:     %s\n' "$root"
+  printf '  Provider: %s\n' "$provider"
+}
+
+config_init_result() {
+  printf 'Configuration saved.\n'
+  printf 'root=%s\n' "$(config_get root)"
+  printf 'provider=%s\n' "$(config_get provider)"
+}
+
+config_init_interactive() {
+  local root provider answer choice default_choice confirm
+
+  root=$(config_get root)
+  provider=$(config_get provider)
+  validate_value provider "$provider"
+
+  printf 'Pantheon Local Tools setup\n\n'
+  printf 'Local checkout root [%s]: ' "$root"
+  IFS= read -r answer || die 'interactive setup ended before root selection'
+  [ -z "$answer" ] || root=$answer
+  root=$(expand_home "$root")
+  validate_value root "$root"
+
+  case "$provider" in
+    auto) default_choice=1 ;;
+    ddev) default_choice=2 ;;
+    lando) default_choice=3 ;;
+    *) die "unsupported configured provider: $provider" ;;
+  esac
+
+  while :; do
+    printf '\nProvider:\n'
+    printf '  1) Auto - use the project DDEV or Lando configuration (recommended)\n'
+    printf '  2) DDEV\n'
+    printf '  3) Lando\n'
+    printf 'Choice [%s]: ' "$default_choice"
+    IFS= read -r choice || die 'interactive setup ended before provider selection'
+    [ -n "$choice" ] || choice=$default_choice
+    case "$choice" in
+      1|auto|Auto|AUTO) provider=auto; break ;;
+      2|ddev|DDEV|Ddev) provider=ddev; break ;;
+      3|lando|Lando|LANDO) provider=lando; break ;;
+      *) printf 'Please choose 1, 2, or 3.\n' >&2 ;;
+    esac
+  done
+  validate_value provider "$provider"
+
+  printf '\n'
+  config_init_summary "$root" "$provider"
+
+  while :; do
+    printf '\nSave configuration? [Y/n] '
+    IFS= read -r confirm || die 'interactive setup ended before confirmation'
+    case "$confirm" in
+      ''|y|Y|yes|YES|Yes) break ;;
+      n|N|no|NO|No)
+        printf 'Configuration not changed.\n'
+        return
+        ;;
+      *) printf 'Please answer y or n.\n' >&2 ;;
+    esac
+  done
+
+  # Both values have been normalized and validated before either write.
+  config_set root "$root"
+  config_set provider "$provider"
+  config_init_result
+}
+
+config_init_command() {
+  local root='' provider='' root_set=false provider_set=false
+
+  if [ "$#" -eq 0 ]; then
+    [ -t 0 ] || die 'interactive config init requires a terminal; supply --root PATH and/or --provider auto|ddev|lando'
+    config_init_interactive
+    return
+  fi
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --root)
+        [ "$#" -ge 2 ] || die '--root requires an absolute path or ~/path'
+        root=$2
+        root_set=true
+        shift 2
+        ;;
+      --provider)
+        [ "$#" -ge 2 ] || die '--provider requires auto, ddev, or lando'
+        provider=$2
+        provider_set=true
+        shift 2
+        ;;
+      -h|--help|help)
+        printf 'Usage: pantheon-local config init [--root PATH] [--provider auto|ddev|lando]\n'
+        printf 'With no options in a terminal, starts guided setup.\n'
+        return
+        ;;
+      *) die "unknown config init option: $1" ;;
+    esac
+  done
+
+  [ "$root_set" = true ] || [ "$provider_set" = true ] ||
+    die 'config init requires --root and/or --provider outside guided setup'
+
+  if [ "$root_set" = true ]; then
+    root=$(expand_home "$root")
+    validate_value root "$root"
+  fi
+  if [ "$provider_set" = true ]; then
+    validate_value provider "$provider"
+  fi
+
+  # Validate every requested value before writing any of them.
+  [ "$root_set" = false ] || config_set root "$root"
+  [ "$provider_set" = false ] || config_set provider "$provider"
+  config_init_result
+}
+
 config_command() {
   local action=${1:-}
   case "$action" in
+    init)
+      shift
+      config_init_command "$@"
+      ;;
     path)
       [ "$#" -eq 1 ] || die 'usage: pantheon-local config path'
       config_path

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -13,6 +13,19 @@ fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 assert_eq() { [ "$1" = "$2" ] || fail "expected [$2], got [$1]"; }
 assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
 
+run_guided_init() {
+  input=$1
+  command -v script >/dev/null 2>&1 || fail 'script command is required for guided config tests'
+  case "$(uname -s)" in
+    Darwin)
+      printf '%b' "$input" | script -q /dev/null bash "$CLI" config init
+      ;;
+    *)
+      printf '%b' "$input" | script -q -c "bash \"$CLI\" config init" /dev/null
+      ;;
+  esac
+}
+
 # The documented example must remain valid Git config data, not executable shell.
 assert_eq "$(git config --file "$REPO_ROOT/config.example" --get local.provider)" 'auto'
 if grep -Eq '(^|[[:space:]])(declare|source|eval)[[:space:]]' "$REPO_ROOT/config.example"; then
@@ -22,6 +35,59 @@ fi
 assert_eq "$(bash "$CLI" config path)" "$PANTHEON_LOCAL_CONFIG"
 assert_eq "$(bash "$CLI" config get provider)" 'auto'
 assert_eq "$(bash "$CLI" config get root)" "$HOME/sites/pantheon"
+
+# No-option init is intentionally interactive and must not hang in automation.
+non_tty_output="$TMP_ROOT/non-tty.out"
+if bash "$CLI" config init </dev/null >"$non_tty_output" 2>&1; then
+  fail 'config init without flags unexpectedly succeeded without a terminal'
+fi
+assert_contains "$(cat "$non_tty_output")" 'interactive config init requires a terminal'
+
+# Flags provide the concise, non-interactive path and may be supplied independently.
+rm -f "$PANTHEON_LOCAL_CONFIG"
+output=$(bash "$CLI" config init --provider ddev)
+assert_contains "$output" 'Configuration saved.'
+assert_contains "$output" 'provider=ddev'
+assert_eq "$(bash "$CLI" config get provider)" 'ddev'
+assert_eq "$(bash "$CLI" config get root)" "$HOME/sites/pantheon"
+
+bash "$CLI" config init --root "$HOME/Flag Root" >/dev/null
+assert_eq "$(bash "$CLI" config get root)" "$HOME/Flag Root"
+assert_eq "$(bash "$CLI" config get provider)" 'ddev'
+
+bash "$CLI" config init --root "$HOME/Both Root" --provider lando >/dev/null
+assert_eq "$(bash "$CLI" config get root)" "$HOME/Both Root"
+assert_eq "$(bash "$CLI" config get provider)" 'lando'
+
+# Validate all requested values before writing any of them.
+if bash "$CLI" config init --root "$HOME/Must Not Persist" --provider nope >/dev/null 2>&1; then
+  fail 'config init accepted an invalid provider'
+fi
+assert_eq "$(bash "$CLI" config get root)" "$HOME/Both Root"
+assert_eq "$(bash "$CLI" config get provider)" 'lando'
+
+# Guided setup uses effective defaults/current values and confirms before writing.
+rm -f "$PANTHEON_LOCAL_CONFIG"
+output=$(run_guided_init '\n\n\n')
+assert_contains "$output" 'Auto - use the project DDEV or Lando configuration (recommended)'
+assert_contains "$output" 'Configuration saved.'
+assert_eq "$(bash "$CLI" config get root)" "$HOME/sites/pantheon"
+assert_eq "$(bash "$CLI" config get provider)" 'auto'
+
+rm -f "$PANTHEON_LOCAL_CONFIG"
+run_guided_init '\n2\n\n' >/dev/null
+assert_eq "$(bash "$CLI" config get provider)" 'ddev'
+
+rm -f "$PANTHEON_LOCAL_CONFIG"
+run_guided_init '\n3\n\n' >/dev/null
+assert_eq "$(bash "$CLI" config get provider)" 'lando'
+
+bash "$CLI" config set root "$HOME/Keep Root"
+bash "$CLI" config set provider auto
+output=$(run_guided_init "$HOME/Cancelled Root\n2\nn\n")
+assert_contains "$output" 'Configuration not changed.'
+assert_eq "$(bash "$CLI" config get root)" "$HOME/Keep Root"
+assert_eq "$(bash "$CLI" config get provider)" 'auto'
 
 tilde='~'
 bash "$CLI" config set root "$tilde/Pantheon Sites"

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -15,13 +15,15 @@ assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain 
 
 run_guided_init() {
   input=$1
+  input_file="$TMP_ROOT/guided-input"
   command -v script >/dev/null 2>&1 || fail 'script command is required for guided config tests'
+  printf '%b' "$input" > "$input_file"
   case "$(uname -s)" in
     Darwin)
-      printf '%b' "$input" | script -q /dev/null bash "$CLI" config init
+      script -q /dev/null bash "$CLI" config init < "$input_file"
       ;;
     *)
-      printf '%b' "$input" | script -q -c "bash \"$CLI\" config init" /dev/null
+      script -q -c "bash \"$CLI\" config init" /dev/null < "$input_file"
       ;;
   esac
 }

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -20,10 +20,12 @@ run_guided_init() {
   printf '%b' "$input" > "$input_file"
   case "$(uname -s)" in
     Darwin)
-      script -q /dev/null bash "$CLI" config init < "$input_file"
+      # BSD script may report a wrapper-level nonzero status at PTY EOF even
+      # after the child completed. Assertions below verify output and state.
+      script -q /dev/null bash "$CLI" config init < "$input_file" || true
       ;;
     *)
-      script -q -c "bash \"$CLI\" config init" /dev/null < "$input_file"
+      script -q -c "bash \"$CLI\" config init" /dev/null < "$input_file" || true
       ;;
   esac
 }

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -15,19 +15,42 @@ assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain 
 
 run_guided_init() {
   input=$1
-  input_file="$TMP_ROOT/guided-input"
-  command -v script >/dev/null 2>&1 || fail 'script command is required for guided config tests'
-  printf '%b' "$input" > "$input_file"
-  case "$(uname -s)" in
-    Darwin)
-      # BSD script may report a wrapper-level nonzero status at PTY EOF even
-      # after the child completed. Assertions below verify output and state.
-      script -q /dev/null bash "$CLI" config init < "$input_file" || true
-      ;;
-    *)
-      script -q -c "bash \"$CLI\" config init" /dev/null < "$input_file" || true
-      ;;
-  esac
+  command -v python3 >/dev/null 2>&1 || fail 'python3 is required for guided config PTY tests'
+  python3 - "$CLI" "$input" <<'PY'
+import errno
+import os
+import pty
+import sys
+
+cli = sys.argv[1]
+data = sys.argv[2].encode()
+pid, fd = pty.fork()
+if pid == 0:
+    os.execv('/bin/bash', ['bash', cli, 'config', 'init'])
+
+while data:
+    written = os.write(fd, data)
+    data = data[written:]
+
+while True:
+    try:
+        chunk = os.read(fd, 4096)
+    except OSError as exc:
+        if exc.errno == errno.EIO:
+            break
+        raise
+    if not chunk:
+        break
+    sys.stdout.buffer.write(chunk)
+    sys.stdout.buffer.flush()
+
+_, status = os.waitpid(pid, 0)
+if os.WIFEXITED(status):
+    raise SystemExit(os.WEXITSTATUS(status))
+if os.WIFSIGNALED(status):
+    raise SystemExit(128 + os.WTERMSIG(status))
+raise SystemExit(1)
+PY
 }
 
 # The documented example must remain valid Git config data, not executable shell.
@@ -72,23 +95,23 @@ assert_eq "$(bash "$CLI" config get provider)" 'lando'
 
 # Guided setup uses effective defaults/current values and confirms before writing.
 rm -f "$PANTHEON_LOCAL_CONFIG"
-output=$(run_guided_init '\n\n\n')
+output=$(run_guided_init $'\n\n\n')
 assert_contains "$output" 'Auto - use the project DDEV or Lando configuration (recommended)'
 assert_contains "$output" 'Configuration saved.'
 assert_eq "$(bash "$CLI" config get root)" "$HOME/sites/pantheon"
 assert_eq "$(bash "$CLI" config get provider)" 'auto'
 
 rm -f "$PANTHEON_LOCAL_CONFIG"
-run_guided_init '\n2\n\n' >/dev/null
+run_guided_init $'\n2\n\n' >/dev/null
 assert_eq "$(bash "$CLI" config get provider)" 'ddev'
 
 rm -f "$PANTHEON_LOCAL_CONFIG"
-run_guided_init '\n3\n\n' >/dev/null
+run_guided_init $'\n3\n\n' >/dev/null
 assert_eq "$(bash "$CLI" config get provider)" 'lando'
 
 bash "$CLI" config set root "$HOME/Keep Root"
 bash "$CLI" config set provider auto
-output=$(run_guided_init "$HOME/Cancelled Root\n2\nn\n")
+output=$(run_guided_init "$HOME/Cancelled Root"$'\n2\nn\n')
 assert_contains "$output" 'Configuration not changed.'
 assert_eq "$(bash "$CLI" config get root)" "$HOME/Keep Root"
 assert_eq "$(bash "$CLI" config get provider)" 'auto'


### PR DESCRIPTION
Closes #47.

## What changed
- add `pantheon-local config init` as a guided first-run setup when invoked without options in a terminal;
- keep `config set/get/unset/list` unchanged as first-class granular controls;
- support `--root` and `--provider` independently or together for concise non-interactive setup;
- explain `auto` as project-config detection for DDEV/Lando and keep it the recommended default;
- summarize and confirm interactive choices before writing;
- fail clearly instead of hanging when no-option init is used without a TTY;
- validate every requested value before any write so invalid combined input cannot leave a partial configuration;
- add isolated config tests for flag-only setup, partial flags, invalid no-partial-write behavior, guided defaults, DDEV, Lando, cancellation, and non-TTY behavior.

The existing granular config interface is not renamed, replaced, or deprecated. Quick-start promotion is intentionally deferred until this command is present in a stable packaged release, per #47.