### PR TITLE
Make CLI help a complete command reference

### DIFF
--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -5,15 +5,80 @@ PROGRAM_NAME="pantheon-local"
 
 usage() {
   cat <<'USAGE'
+Pantheon Local Tools
+
 Usage:
-  pantheon-local config ...
+  pantheon-local COMMAND [OPTIONS]
+
+Commands:
+  pantheon-local config init [--root PATH] [--provider auto|ddev|lando]
+      Guided first-run setup. With flags, configure root and/or provider
+      non-interactively.
+
+  pantheon-local config path
+      Print the active configuration file path.
+
+  pantheon-local config get KEY
+      Print the effective value for a configuration key.
+
+  pantheon-local config set KEY VALUE
+      Set one configuration value. Supported keys: root, provider.
+
+  pantheon-local config unset KEY
+      Remove one stored configuration value so its default applies again.
+
+  pantheon-local config list
+      Print effective root/provider values and configured Pantheon Tag routes.
+
+  pantheon-local config tag get TAG
+      Print the local directory mapped to a Pantheon Tag.
+
+  pantheon-local config tag set TAG DIRECTORY
+      Map a Pantheon Tag to a directory relative to the configured root.
+
+  pantheon-local config tag unset TAG
+      Remove a Pantheon Tag directory mapping.
+
+  pantheon-local config tag list
+      List all configured Pantheon Tag directory mappings.
+
   pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]
+      Clone a Pantheon Multidev into an isolated local checkout. --dry-run
+      prints the plan without writing; --start explicitly starts the provider.
+
   pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]
+      Refresh local Pantheon database/files without changing checked-out Git
+      code. By default both database and files are pulled.
+
   pantheon-local status
+      Show local checkout/provider/data-source status without contacting
+      Pantheon or starting a provider.
+
   pantheon-local version
   pantheon-local --version
+      Print the installed Pantheon Local Tools version.
 
-Run `pantheon-local config help` for configuration commands.
+Provider selection:
+  auto   Detect from project configuration after checkout: .ddev/config.yaml
+         selects DDEV and .lando.yml selects Lando. If both or neither are
+         present, the tool refuses to guess and asks for an explicit provider.
+  ddev   Use DDEV.
+  lando  Use Lando.
+
+Examples:
+  pantheon-local config init
+  pantheon-local config init --provider ddev
+  pantheon-local multidev example.feature --dry-run
+  pantheon-local pull test --database-only
+  pantheon-local status
+
+Help:
+  pantheon-local help
+  pantheon-local config help
+  pantheon-local config init --help
+  pantheon-local multidev --help
+  pantheon-local pull --help
+  pantheon-local status --help
 USAGE
 }
 

--- a/install-apt.sh
+++ b/install-apt.sh
@@ -83,4 +83,5 @@ run_privileged apt-get update
 run_privileged apt-get install --yes pantheon-local-tools
 
 printf 'Pantheon Local Tools is installed.\n'
-printf 'Run: pantheon-local --version\n'
+printf 'Next: pantheon-local config init\n'
+printf 'Help: pantheon-local help\n'

--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+CLI=${CLI:-"$REPO_ROOT/bin/pantheon-local"}
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() { [ "$1" = "$2" ] || fail "expected outputs to match"; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected help to contain [$2]" ;; esac; }
+
+help_output=$(bash "$CLI" help)
+assert_eq "$help_output" "$(bash "$CLI" --help)"
+assert_eq "$help_output" "$(bash "$CLI")"
+
+for expected in \
+  'pantheon-local config init [--root PATH] [--provider auto|ddev|lando]' \
+  'pantheon-local config path' \
+  'pantheon-local config get KEY' \
+  'pantheon-local config set KEY VALUE' \
+  'pantheon-local config unset KEY' \
+  'pantheon-local config list' \
+  'pantheon-local config tag get TAG' \
+  'pantheon-local config tag set TAG DIRECTORY' \
+  'pantheon-local config tag unset TAG' \
+  'pantheon-local config tag list' \
+  'pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]' \
+  'pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]' \
+  'pantheon-local status' \
+  'pantheon-local version' \
+  'pantheon-local --version' \
+  'auto   Detect from project configuration after checkout' \
+  'pantheon-local multidev example.feature --dry-run' \
+  'pantheon-local pull test --database-only'
+do
+  assert_contains "$help_output" "$expected"
+done
+
+config_help=$(bash "$CLI" config help)
+assert_contains "$config_help" 'pantheon-local config init [--root PATH] [--provider auto|ddev|lando]'
+assert_contains "$config_help" 'pantheon-local config tag set TAG DIRECTORY'
+
+init_help=$(bash "$CLI" config init --help)
+assert_contains "$init_help" 'Usage: pantheon-local config init [--root PATH] [--provider auto|ddev|lando]'
+assert_contains "$init_help" 'guided setup'
+
+multidev_help=$(bash "$CLI" multidev --help)
+assert_contains "$multidev_help" 'pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]'
+
+pull_help=$(bash "$CLI" pull --help)
+assert_contains "$pull_help" 'pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]'
+assert_contains "$pull_help" 'without changing checked-out Git code'
+
+status_help=$(bash "$CLI" status --help)
+assert_contains "$status_help" 'pantheon-local status'
+assert_contains "$status_help" 'without contacting Pantheon or starting a provider'
+
+printf 'help tests passed\n'

--- a/tests/test-install-apt.sh
+++ b/tests/test-install-apt.sh
@@ -94,6 +94,14 @@ case "$install_output" in
   *'Pantheon Local Tools is installed.'*) ;;
   *) fail 'installer did not report successful completion' ;;
 esac
+case "$install_output" in
+  *'Next: pantheon-local config init'*) ;;
+  *) fail 'installer did not point to guided configuration' ;;
+esac
+case "$install_output" in
+  *'Help: pantheon-local help'*) ;;
+  *) fail 'installer did not point to in-tool help' ;;
+esac
 
 assert_file_contains "$CALL_LOG" 'curl keyring'
 assert_file_contains "$CALL_LOG" 'sudo install -d -m 0755 /etc/apt/keyrings /etc/apt/sources.list.d'


### PR DESCRIPTION
Closes #51.

## What changed
- make `pantheon-local`, `pantheon-local help`, and `pantheon-local --help` print the complete public command surface;
- list every config/tag command plus Multidev, pull, status, and version with concise operator-facing descriptions;
- show the important flags directly in the command map;
- explain that `provider=auto` detects project configuration (`.ddev/config.yaml` vs `.lando.yml`) and fails closed when detection is ambiguous;
- include representative first-run, Multidev, pull, and status examples;
- keep focused command help routes working;
- point successful APT installs directly to `pantheon-local config init` and `pantheon-local help`;
- add regression coverage for the complete top-level help surface and focused help routes.

This keeps the executable self-documenting in the same spirit as the Home Infra tooling: install the tool, ask it for help, and see what it can do without opening repository docs.