### PR TITLE
Keep APT installer guidance compatible with stable CLI

### DIFF
--- a/install-apt.sh
+++ b/install-apt.sh
@@ -83,5 +83,5 @@ run_privileged apt-get update
 run_privileged apt-get install --yes pantheon-local-tools
 
 printf 'Pantheon Local Tools is installed.\n'
-printf 'Next: pantheon-local config init\n'
+printf 'Run: pantheon-local --version\n'
 printf 'Help: pantheon-local help\n'

--- a/tests/test-install-apt.sh
+++ b/tests/test-install-apt.sh
@@ -95,12 +95,15 @@ case "$install_output" in
   *) fail 'installer did not report successful completion' ;;
 esac
 case "$install_output" in
-  *'Next: pantheon-local config init'*) ;;
-  *) fail 'installer did not point to guided configuration' ;;
+  *'Run: pantheon-local --version'*) ;;
+  *) fail 'installer did not point to a stable-safe version check' ;;
 esac
 case "$install_output" in
   *'Help: pantheon-local help'*) ;;
   *) fail 'installer did not point to in-tool help' ;;
+esac
+case "$install_output" in
+  *'pantheon-local config init'*) fail 'installer advertised unreleased config init' ;;
 esac
 
 assert_file_contains "$CALL_LOG" 'curl keyring'


### PR DESCRIPTION
Closes #53.

`install-apt.sh` is fetched from `main` but installs the current stable APT package, so its post-install guidance must not advertise commands that only exist on unreleased `main`.

- restore the stable-safe `pantheon-local --version` next step;
- retain `pantheon-local help` as the discovery pointer;
- stop advertising `config init` until a stable package contains it;
- add a regression assertion so bootstrap guidance cannot drift ahead of the published CLI again.

No APT trust, source, package, or installation behavior changes.