### PR TITLE
Add initial product-page discovery metadata

### DIFF
--- a/packaging/debian/apt-index.html
+++ b/packaging/debian/apt-index.html
@@ -6,6 +6,13 @@
   <meta name="theme-color" content="#02060b">
   <meta name="color-scheme" content="dark">
   <meta name="description" content="Pantheon Local Tools is a free, provider-neutral CLI for safer Pantheon local development with DDEV and Lando.">
+  <link rel="canonical" href="https://zevarix.github.io/pantheon-local-tools/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Pantheon Local Tools">
+  <meta property="og:title" content="Pantheon Local Tools — Safer Pantheon local development">
+  <meta property="og:description" content="Pantheon Local Tools is a free, provider-neutral CLI for safer Pantheon local development with DDEV and Lando.">
+  <meta property="og:url" content="https://zevarix.github.io/pantheon-local-tools/">
+  <meta name="twitter:card" content="summary">
   <title>Pantheon Local Tools — Safer Pantheon local development</title>
   <link rel="stylesheet" href="apt-index.css">
   <style>


### PR DESCRIPTION
## Summary

Implements the smallest first-pass discoverability baseline for issue #57 while preserving the existing signed APT/GitHub Pages publication architecture.

- adds a self-referencing canonical URL for the public product-page endpoint;
- adds basic Open Graph metadata;
- adds a lightweight Twitter card declaration;
- keeps the existing title, description, product copy, builder, signing flow, and publication workflow unchanged.

## Scope intentionally deferred

- no keyword/content rewrite;
- no speculative schema markup;
- no separate site stack;
- no ineffective project-subpath `robots.txt`;
- no builder change solely to add a one-page sitemap;
- no copied SuperSEO source.

The implementation was informed by the bounded SuperSEO `page-audit` proving-ground work in `Zevarix-Studios/agent-library#19`, but recommendations were constrained by current primary search guidance and the owning repository's signed-distribution architecture.

## Validation

The branch changes only `packaging/debian/apt-index.html`; the canonical publication builder continues to copy that file into the generated APT Pages output as `index.html`. Post-merge/publication validation still needs to confirm the live Pages head matches the canonical source.

Relates to #57.