### PR TITLE
Add IndexNow notifications after Pages publication

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -1,0 +1,99 @@
+name: Notify IndexNow
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/indexnow.yml'
+      - 'packaging/debian/9afcbbbd3f35a9d0829a54311c12ba52.txt'
+      - 'packaging/debian/build-apt-repository.sh'
+      - 'packaging/debian/apt-index.html'
+  workflow_run:
+    workflows:
+      - Publish APT Repository
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+env:
+  INDEXNOW_KEY: 9afcbbbd3f35a9d0829a54311c12ba52
+  INDEXNOW_KEY_LOCATION: https://zevarix.github.io/pantheon-local-tools/9afcbbbd3f35a9d0829a54311c12ba52.txt
+  INDEXNOW_URL: https://zevarix.github.io/pantheon-local-tools/
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate IndexNow source key
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          key_file="packaging/debian/${INDEXNOW_KEY}.txt"
+          [ -f "$key_file" ] || {
+            printf 'IndexNow source key file is missing: %s\n' "$key_file" >&2
+            exit 1
+          }
+
+          [ "$(cat "$key_file")" = "$INDEXNOW_KEY" ] || {
+            echo 'IndexNow source key file does not match the configured key' >&2
+            exit 1
+          }
+
+          bash -n packaging/debian/build-apt-repository.sh
+
+  notify:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify published IndexNow key
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          served_key=$(
+            curl --fail --silent --show-error --location \
+              --retry 5 --retry-delay 2 \
+              "$INDEXNOW_KEY_LOCATION"
+          )
+
+          [ "$served_key" = "$INDEXNOW_KEY" ] || {
+            echo 'published IndexNow key does not match the configured key' >&2
+            exit 1
+          }
+
+      - name: Notify IndexNow
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          response_file="$RUNNER_TEMP/indexnow-response.txt"
+          http_code=$(
+            curl --silent --show-error --location \
+              --retry 3 --retry-delay 2 --retry-all-errors \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              --get 'https://api.indexnow.org/indexnow' \
+              --data-urlencode "url=$INDEXNOW_URL" \
+              --data-urlencode "key=$INDEXNOW_KEY" \
+              --data-urlencode "keyLocation=$INDEXNOW_KEY_LOCATION"
+          )
+
+          case "$http_code" in
+            200|202)
+              printf 'IndexNow accepted %s with HTTP %s\n' "$INDEXNOW_URL" "$http_code"
+              ;;
+            *)
+              printf 'IndexNow returned HTTP %s\n' "$http_code" >&2
+              cat "$response_file" >&2 || true
+              exit 1
+              ;;
+          esac

--- a/packaging/debian/9afcbbbd3f35a9d0829a54311c12ba52.txt
+++ b/packaging/debian/9afcbbbd3f35a9d0829a54311c12ba52.txt
@@ -1,0 +1,1 @@
+9afcbbbd3f35a9d0829a54311c12ba52

--- a/packaging/debian/apt-index.html
+++ b/packaging/debian/apt-index.html
@@ -13,6 +13,7 @@
   <meta property="og:description" content="Pantheon Local Tools is a free, provider-neutral CLI for safer Pantheon local development with DDEV and Lando.">
   <meta property="og:url" content="https://zevarix.github.io/pantheon-local-tools/">
   <meta name="twitter:card" content="summary">
+  <!-- IndexNow verification is published as a sibling key file by the APT repository builder. -->
   <title>Pantheon Local Tools — Safer Pantheon local development</title>
   <link rel="stylesheet" href="apt-index.css">
   <style>

--- a/packaging/debian/build-apt-repository.sh
+++ b/packaging/debian/build-apt-repository.sh
@@ -16,6 +16,8 @@ require_command() {
 
 REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
 VERSION_FILE="$REPO_ROOT/VERSION"
+INDEXNOW_KEY='9afcbbbd3f35a9d0829a54311c12ba52'
+INDEXNOW_KEY_FILE="$REPO_ROOT/packaging/debian/${INDEXNOW_KEY}.txt"
 OUTPUT_DIR=$1
 shift
 
@@ -42,6 +44,11 @@ case "$CURRENT_VERSION" in
   *$'\n'*|*$'\r'*) die 'current repository version must be a single line' ;;
 esac
 
+[ -f "$INDEXNOW_KEY_FILE" ] ||
+  die "IndexNow key file not found: $INDEXNOW_KEY_FILE"
+[ "$(cat "$INDEXNOW_KEY_FILE")" = "$INDEXNOW_KEY" ] ||
+  die 'IndexNow key file content does not match the configured key'
+
 case "$OUTPUT_DIR" in
   /*) ;;
   *) OUTPUT_DIR="$PWD/$OUTPUT_DIR" ;;
@@ -62,6 +69,7 @@ trap 'rm -rf "$STAGE"' EXIT HUP INT TERM
 POOL_REL='pool/main/p/pantheon-local-tools'
 INDEX_REL='dists/stable/main/binary-all'
 install -d "$STAGE/$POOL_REL" "$STAGE/$INDEX_REL"
+install -m 0644 "$INDEXNOW_KEY_FILE" "$STAGE/$INDEXNOW_KEY.txt"
 
 CURRENT_VERSION_PRESENT=0
 


### PR DESCRIPTION
## Summary

Implements #62 without creating a second PLT deployment path.

- adds a public IndexNow key source under `packaging/debian/`;
- makes the existing deterministic APT repository builder copy that key into the published Pages root;
- documents the sibling verification file in the landing-page source;
- validates the key source on PRs;
- after a successful non-PR `Publish APT Repository` run, verifies the live key file and notifies IndexNow for the canonical product page using the required subpath `keyLocation`;
- preserves signing, package metadata, Pages deployment, and public APT validation boundaries.

Google Search Console onboarding remains separate.

Closes #62.