### PR TITLE
Add Google Search Console verification tag

### DIFF
--- a/packaging/debian/apt-index.html
+++ b/packaging/debian/apt-index.html
@@ -6,6 +6,7 @@
   <meta name="theme-color" content="#02060b">
   <meta name="color-scheme" content="dark">
   <meta name="description" content="Pantheon Local Tools is a free, provider-neutral CLI for safer Pantheon local development with DDEV and Lando.">
+  <meta name="google-site-verification" content="2Mf5s5Svt4s8KUgXUoFKFgyF2uiW03wVTzRezjFJBFk">
   <link rel="canonical" href="https://zevarix.github.io/pantheon-local-tools/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Pantheon Local Tools">


### PR DESCRIPTION
## Summary

Implements #64 with the exact Google-provided URL-prefix verification tag for `https://zevarix.github.io/pantheon-local-tools/`.

- adds one `<meta name="google-site-verification">` tag to `packaging/debian/apt-index.html`;
- makes no other SEO/content/schema changes;
- preserves the existing signed APT/GitHub Pages build and deployment architecture;
- after merge, the production page will be checked for the exact token before Search Console verification.

Closes #64.