### PR TITLE
Add provider-aware Drupal checkout setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ The project follows Semantic Versioning for its public command/configuration con
 
 - Added optional Pantheon Tag profile properties in the existing Git-compatible configuration file: `config-strategy` (`full-export` or `overlay-delta`) and a validated project-relative `config-path`.
 - Added `pantheon-local config tag profile get/set/unset/list` with focused help, regression coverage, generic examples, and no organization-specific built-ins.
+- Added checkout-local `pantheon-local setup [--provider ddev|lando] [--dry-run]` for provider-aware Drupal bootstrap using the checkout's recorded Pantheon environment.
+- Added bootstrap status/step/timestamp reporting to checkout-local state and `pantheon-local status`.
 
 ### Changed
 
 - `pantheon-local config list` now reports configured Tag profile properties in addition to the established root/provider and Tag-directory lines.
 - `pantheon-local config tag unset TAG` now removes that Tag's optional profile properties so stale strategy/path state is not orphaned after route deletion.
-- Debian/Homebrew/release packaging coverage now includes the Tag-profile command module.
+- Debian/Homebrew/release packaging coverage now includes the Tag-profile and Drupal-setup command modules.
+- Drupal setup now composes the existing guarded database-only pull after provider-owned Composer install, then runs `drush updb -y` and `drush cr`, stopping on the first failed step.
 
 ## 0.1.1 — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ pantheon-local multidev SITE.ENV --provider ddev --start
 
 Use `lando` instead of `ddev` when that is the project/provider you want.
 
+For a PLT-managed Drupal checkout, inspect the bootstrap plan before replacing local database data:
+
+```bash
+cd /path/to/the/checkout
+pantheon-local setup --dry-run
+```
+
+Then run the provider-aware Drupal bootstrap explicitly:
+
+```bash
+pantheon-local setup
+```
+
+Setup starts the selected provider, runs Composer inside that provider, reuses the guarded database-only pull from the checkout's recorded Pantheon environment, then runs `drush updb -y` and `drush cr`. See [`docs/setup.md`](docs/setup.md) for its mutation and retry contract.
+
 ## Commands
 
 Run `pantheon-local help` or `pantheon-local --help` for the complete in-tool command reference.
@@ -134,6 +149,10 @@ pantheon-local multidev SITE.ENV
   --dry-run
   --start
 
+pantheon-local setup
+  --provider ddev|lando
+  --dry-run
+
 pantheon-local pull ENV
   --database-only
   --files-only
@@ -144,7 +163,7 @@ pantheon-local version
 pantheon-local --version
 ```
 
-Focused help remains available for nontrivial commands, for example `pantheon-local config help`, `pantheon-local config tag profile --help`, `pantheon-local multidev --help`, `pantheon-local pull --help`, and `pantheon-local status --help`.
+Focused help remains available for nontrivial commands, for example `pantheon-local config help`, `pantheon-local config tag profile --help`, `pantheon-local multidev --help`, `pantheon-local setup --help`, `pantheon-local pull --help`, and `pantheon-local status --help`.
 
 ## Core workflows
 
@@ -152,9 +171,21 @@ Focused help remains available for nontrivial commands, for example `pantheon-lo
 
 `pantheon-local multidev SITE.ENV` clones an **existing** Pantheon Multidev into an isolated local checkout. It does not create, delete, or mutate the remote Pantheon environment.
 
-The command resolves the authoritative Git URL through Terminus, applies user-configured Pantheon Tag routing when present, refuses occupied destinations, configures the selected local provider additively, and finalizes the checkout only after local setup succeeds. `--dry-run` resolves and prints the plan without cloning; `--start` is explicit.
+The command resolves the authoritative Git URL through Terminus, applies user-configured Pantheon Tag routing when present, refuses occupied destinations, configures the selected local provider additively, and finalizes the checkout only after local setup succeeds. `--dry-run` resolves and prints the plan without cloning; `--start` is explicit and continues to mean provider start only.
 
 See [`docs/multidev.md`](docs/multidev.md) for the full workflow and safety contract.
+
+### Drupal checkout setup
+
+`pantheon-local setup` bootstraps an existing **PLT-managed Drupal checkout** using the Pantheon environment recorded when the checkout was created. It refuses to infer that source from the Git branch or silently substitute Live.
+
+The required order is provider start → provider-owned `composer install` → existing guarded `pull --database-only` → provider-owned `drush updb -y` → provider-owned `drush cr`. The pipeline stops on the first failed mutating step and records the failed/current/completed bootstrap step in checkout-local PLT state.
+
+`--dry-run` performs local preflight and prints the exact plan without starting the provider, running Composer/Drush, pulling data, or changing bootstrap state. A real setup run is explicitly local and mutating: Composer may access the network and run project scripts, the local database is replaced from the recorded Pantheon environment, and Drush updates local database/cache state.
+
+Setup does not pull files or Git code, export Drupal configuration, push to Pantheon, or rewrite provider-owned base configuration. `multidev --start` remains start-only; setup is a separate command.
+
+See [`docs/setup.md`](docs/setup.md) for provider mappings, preflight, failure/retry behavior, upstream references, and state fields.
 
 ### Data pulls
 
@@ -174,7 +205,7 @@ See [`docs/pull.md`](docs/pull.md) for component selection, provider behavior, a
 
 `pantheon-local status` is a local, read-only inspection command. It can run from the checkout root or a subdirectory and does not contact Pantheon or start/rebuild a provider.
 
-For managed checkouts it reports recorded Pantheon identity, provider, Git state, provider-derived runtime URL when available, and independent database/files provenance. Existing DDEV/Lando Git checkouts are also supported; unavailable Pantheon metadata is reported as not recorded rather than guessed.
+For managed checkouts it reports recorded Pantheon identity, provider, Git state, provider-derived runtime URL when available, independent database/files provenance, and the latest recorded Drupal bootstrap status/step/timestamp. Existing DDEV/Lando Git checkouts are also supported; unavailable Pantheon/bootstrap metadata is reported as not recorded rather than guessed.
 
 See [`docs/status.md`](docs/status.md) for the status contract.
 
@@ -249,6 +280,9 @@ Pantheon Local Tools is intentionally conservative around developer machines and
 - existing checkout destinations are never silently overwritten;
 - local checkout creation never creates or deletes a remote Pantheon Multidev;
 - `pantheon-local pull` never pulls Git code;
+- `pantheon-local setup` uses only the checkout's recorded Pantheon environment for its database refresh and never infers Live/current-branch semantics;
+- setup runs Composer inside the selected provider and stops immediately when provider start, Composer, database pull, `updb`, or cache rebuild fails;
+- setup does not pull files/Git code, export config, push to Pantheon, or change the meaning of `multidev --start`;
 - provider/project configuration remains provider-owned;
 - provider detection and Pantheon Tag routing fail on ambiguity rather than guessing;
 - unsupported Tag profile strategies and unsafe project-relative config paths fail instead of being guessed;
@@ -297,6 +331,7 @@ CI runs syntax validation, ShellCheck, and the shell integration suite on Ubuntu
 
 - [`docs/configuration.md`](docs/configuration.md) — Git-compatible user configuration and Pantheon Tag profile strategies
 - [`docs/multidev.md`](docs/multidev.md) — Multidev checkout behavior and safety
+- [`docs/setup.md`](docs/setup.md) — provider-aware Drupal checkout bootstrap, failure/retry behavior, and local mutation boundaries
 - [`docs/pull.md`](docs/pull.md) — database/files pull behavior and Git protection
 - [`docs/status.md`](docs/status.md) — read-only checkout inspection contract
 - [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) — DDEV/Lando boundary and provider architecture

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -60,13 +60,18 @@ Commands:
       Clone a Pantheon Multidev into an isolated local checkout. --dry-run
       prints the plan without writing; --start explicitly starts the provider.
 
+  pantheon-local setup [--provider ddev|lando] [--dry-run]
+      Bootstrap an existing PLT-managed Drupal checkout using its recorded
+      Pantheon environment: start provider, Composer install, guarded local
+      database pull, drush updb, then drush cr. --dry-run prints the plan only.
+
   pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]
       Refresh local Pantheon database/files without changing checked-out Git
       code. By default both database and files are pulled.
 
   pantheon-local status
-      Show local checkout/provider/data-source status without contacting
-      Pantheon or starting a provider.
+      Show local checkout/provider/data-source/bootstrap status without
+      contacting Pantheon or starting a provider.
 
   pantheon-local version
   pantheon-local --version
@@ -90,6 +95,8 @@ Examples:
   pantheon-local config tag profile set 'Example Group' config-strategy full-export
   pantheon-local config tag profile set 'Example Group' config-path config/sync
   pantheon-local multidev example.feature --dry-run
+  pantheon-local setup --dry-run
+  pantheon-local setup
   pantheon-local pull test --database-only
   pantheon-local status
 
@@ -99,6 +106,7 @@ Help:
   pantheon-local config init --help
   pantheon-local config tag profile --help
   pantheon-local multidev --help
+  pantheon-local setup --help
   pantheon-local pull --help
   pantheon-local status --help
 USAGE
@@ -144,6 +152,7 @@ LIBEXEC_DIR="$PROJECT_ROOT/libexec"
 CORE="$LIBEXEC_DIR/pantheon-local-core"
 PROFILE="$LIBEXEC_DIR/pantheon-local-config-profile"
 PULL="$LIBEXEC_DIR/pantheon-local-pull"
+SETUP="$LIBEXEC_DIR/pantheon-local-setup"
 STATUS="$LIBEXEC_DIR/pantheon-local-status"
 
 command=${1:-}
@@ -160,6 +169,11 @@ case "$command" in
     [ -x "$PULL" ] || die "pull module is missing or not executable: $PULL"
     shift
     exec "$PULL" "$@"
+    ;;
+  setup)
+    [ -x "$SETUP" ] || die "setup module is missing or not executable: $SETUP"
+    shift
+    exec "$SETUP" "$@"
     ;;
   status)
     [ -x "$STATUS" ] || die "status module is missing or not executable: $STATUS"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,6 +52,10 @@ pantheon-local multidev SITE.ENV
   --dry-run
   --start
 
+pantheon-local setup
+  --provider ddev|lando
+  --dry-run
+
 pantheon-local pull ENV
   --database-only
   --files-only
@@ -62,9 +66,9 @@ pantheon-local version
 pantheon-local --version
 ```
 
-Running `pantheon-local` with no arguments shows the same top-level command reference as `pantheon-local help` / `pantheon-local --help`. Focused help routes such as `pantheon-local config help`, `pantheon-local config init --help`, `pantheon-local config tag profile --help`, `pantheon-local multidev --help`, `pantheon-local pull --help`, and `pantheon-local status --help` are also supported discovery surfaces.
+Running `pantheon-local` with no arguments shows the same top-level command reference as `pantheon-local help` / `pantheon-local --help`. Focused help routes such as `pantheon-local config help`, `pantheon-local config init --help`, `pantheon-local config tag profile --help`, `pantheon-local multidev --help`, `pantheon-local setup --help`, `pantheon-local pull --help`, and `pantheon-local status --help` are also supported discovery surfaces.
 
-New commands and additive options may be introduced in a compatible `0.1.x` release when they do not change existing command meaning.
+New commands and additive options may be introduced in a compatible `0.1.x` release when they do not change existing command meaning. In particular, adding `pantheon-local setup` does not change `pantheon-local multidev --start`: `--start` continues to mean provider start only.
 
 ## Configuration contract
 
@@ -95,7 +99,29 @@ Provider-owned project configuration remains authoritative. Pantheon Local Tools
 
 When stored configuration uses `provider=auto`, provider selection is based on project configuration after checkout (`.ddev/config.yaml` versus `.lando.yml`), not simply on which provider binaries are installed. Ambiguous detection fails rather than guessing.
 
+`pantheon-local setup` uses provider-owned command surfaces for provider start, Composer, and Drush. Composer is never silently replaced with host Composer when a supported provider owns the checkout runtime. The database refresh remains delegated through the existing provider-specific `pantheon-local pull --database-only` path.
+
 A provider-specific implementation detail may change in a patch release when the user-visible command contract and safety properties remain the same.
+
+## Drupal setup contract
+
+`pantheon-local setup` is available only for a checkout with PLT checkout-local state containing a valid `pantheon.environment`. That recorded environment is authoritative for the setup database refresh. Setup must not infer an environment from the Git branch or silently fall back to `live`.
+
+The public setup order is:
+
+```text
+provider start
+→ provider-owned composer install
+→ guarded database-only pull from recorded pantheon.environment
+→ provider-owned drush updb -y
+→ provider-owned drush cr
+```
+
+Setup stops at the first failed mutating step. It must not continue to database pull after a failed Composer install, to `updb` after a failed pull, or to cache rebuild after a failed `updb`.
+
+`pantheon-local setup --dry-run` may inspect local prerequisites and print the plan, but must not start/rebuild a provider, execute Composer/Drush, pull data, contact Pantheon through the pull path, or mutate checkout-local bootstrap state.
+
+Setup is a local mutation workflow. It may start/build provider runtime services; Composer may access the network and execute project scripts; the database pull replaces local database data; and Drush may mutate the local database/cache. Setup does not pull files or Git code, export Drupal configuration, push to Pantheon, or rewrite provider-owned base project configuration.
 
 ## Safety contract
 
@@ -114,8 +140,11 @@ A compatible `0.1.x` release must preserve these properties:
 - validate all guided `config init` selections before writing so an invalid later value cannot leave a partial configuration update;
 - reject unsupported Tag `config-strategy` values instead of guessing future semantics;
 - reject unsafe/escaping Tag `config-path` values rather than treating them as project-relative paths;
-- never make setting a Tag profile property implicitly create a Pantheon Tag route; and
-- never interpret `overlay-delta` as permission to flatten or fully export Drupal configuration into the configured delta path.
+- never make setting a Tag profile property implicitly create a Pantheon Tag route;
+- never interpret `overlay-delta` as permission to flatten or fully export Drupal configuration into the configured delta path;
+- never let `pantheon-local setup` infer its Pantheon database source from Git branch naming or an implicit Live default;
+- never run setup `updb`/`cr` after an earlier required step fails; and
+- never make `multidev --start` silently perform the full Drupal setup pipeline.
 
 Safety tightening that converts a previously ambiguous/unsafe case into an explicit failure is considered compatible when documented in release notes.
 
@@ -126,6 +155,8 @@ Safety tightening that converts a previously ambiguous/unsafe case into an expli
 Its schema is not a general-purpose external API. However, upgrades must preserve/migrate state created by earlier supported versions rather than silently discarding known provenance or checkout identity.
 
 In particular, the legacy `data.source` migration to independent database/files provenance demonstrates the expected upgrade behavior.
+
+Setup may add local troubleshooting keys for bootstrap status, failed/current step, recorded environment/provider, and update timestamp. `pantheon-local status` may display those fields. Their presence does not make checkout-local state a stable machine API or application configuration.
 
 ## Human-readable output
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,158 @@
+# Drupal checkout setup
+
+`pantheon-local setup` prepares an existing Pantheon Local Tools-managed Drupal checkout for local development without changing the meaning of `pantheon-local multidev --start`.
+
+The command is intentionally checkout-local. Run it from the checkout root or any subdirectory after `pantheon-local multidev SITE.ENV` has created the checkout and recorded its Pantheon identity.
+
+## Command
+
+```bash
+pantheon-local setup [--provider ddev|lando] [--dry-run]
+```
+
+Examples:
+
+```bash
+pantheon-local setup --dry-run
+pantheon-local setup
+pantheon-local setup --provider lando
+```
+
+`--provider` overrides provider selection for this run only. It does not rewrite provider project configuration or global PLT configuration.
+
+## Required pipeline
+
+A mutating setup run executes exactly these phases in order:
+
+```text
+provider start
+→ provider-owned Composer install
+→ guarded database-only pull from the checkout's recorded Pantheon environment
+→ provider-owned drush updb -y
+→ provider-owned drush cr
+```
+
+For Lando this maps to:
+
+```text
+lando start
+lando composer install
+pantheon-local pull RECORDED_ENV --database-only --provider lando
+lando drush updb -y
+lando drush cr
+```
+
+For DDEV this maps to:
+
+```text
+ddev start
+ddev composer install
+pantheon-local pull RECORDED_ENV --database-only --provider ddev
+ddev drush updb -y
+ddev drush cr
+```
+
+The delegated pull remains the existing PLT pull implementation, so provider-owned Pantheon authentication, database provenance, and the Git `HEAD`/tracked-content integrity check stay centralized rather than being reimplemented in setup.
+
+## Pantheon environment authority
+
+Setup requires `.git/pantheon-local-tools/state` and reads `pantheon.environment` from that checkout-local state.
+
+It does **not**:
+
+- infer the Pantheon environment from the current Git branch;
+- silently fall back to `live`;
+- query Pantheon to guess an environment; or
+- accept an unrecorded environment merely because provider configuration exists.
+
+This keeps a checkout cloned from (for example) `SITE.phase1` tied to `phase1` even if the local Git branch is renamed later.
+
+## Preflight
+
+Before any provider command runs, setup verifies:
+
+- it is inside a Git checkout;
+- PLT checkout-local state exists;
+- a valid recorded `pantheon.environment` exists;
+- provider selection is unambiguous or explicitly overridden;
+- the selected provider's project configuration exists;
+- `composer.json` exists at the checkout root;
+- the PLT pull module is installed; and
+- DDEV checkouts contain `.ddev/providers/pantheon.yaml` before setup can reach the destructive local pull.
+
+These checks keep known local failures from starting/rebuilding a provider unnecessarily.
+
+## Dry-run
+
+`pantheon-local setup --dry-run` performs the local preflight and prints the exact planned environment, provider, database source, and five-step pipeline.
+
+Dry-run does not:
+
+- start a provider;
+- run Composer or Composer scripts;
+- run Drush;
+- pull a database;
+- contact Pantheon through the pull path; or
+- update checkout-local bootstrap state.
+
+## Mutation and safety boundaries
+
+Setup is explicitly mutating **locally**:
+
+- provider start may build/rebuild local runtime containers;
+- `composer install` can access the network and execute project-defined Composer scripts;
+- the database-only pull replaces the local database from the recorded Pantheon environment;
+- `drush updb -y` applies pending database updates; and
+- `drush cr` rebuilds Drupal caches.
+
+Setup does not pull files. It does not pull or replace Git code. It does not automatically export Drupal configuration. It does not push code, config, files, or database data to Pantheon.
+
+Provider-owned `.lando.yml`, `.ddev/config.yaml`, services, add-ons, Compose extensions, and tooling remain authoritative. Setup invokes provider commands; it does not rewrite those base definitions.
+
+## Failure and retry behavior
+
+Before each mutating phase, setup records the active step as `in-progress` in checkout-local PLT state. If the phase fails, setup records `failed` plus the exact failed step and stops immediately.
+
+The recorded step names are:
+
+- `provider-start`;
+- `composer-install`;
+- `database-pull`;
+- `drush-updb`;
+- `drush-cr`; and
+- `complete` after success.
+
+No later phase runs after a failure. In particular:
+
+- a failed provider start prevents Composer;
+- a failed Composer install prevents database pull;
+- a failed database pull prevents both Drush commands;
+- a failed `updb` prevents cache rebuild.
+
+Fix the reported problem and rerun `pantheon-local setup`. The command deliberately starts from phase 1 again rather than trying to infer that a previously successful mutating phase is safe to skip.
+
+## Status and provenance
+
+Successful database provenance continues to be owned by `pantheon-local pull`, which records `data.database-source` only after provider success and Git-integrity verification.
+
+Setup additionally records checkout-local bootstrap metadata:
+
+```text
+bootstrap.status
+bootstrap.step
+bootstrap.environment
+bootstrap.provider
+bootstrap.updated-at
+```
+
+`pantheon-local status` reports the latest bootstrap status, step, and timestamp. These values are local troubleshooting metadata under `.git/pantheon-local-tools/state`; they are not application configuration and must not be committed.
+
+## Provider references
+
+PLT follows the providers' supported command surfaces rather than shelling into containers with hand-built Docker commands:
+
+- Lando start / Drupal tooling: https://docs.lando.dev/getting-started/first-app.html and https://docs.lando.dev/plugins/drupal/v/dev/tooling.html
+- DDEV commands (`start`, `composer`, `drush`): https://docs.ddev.com/en/stable/users/usage/commands/
+- DDEV Pantheon provider/pull integration: https://docs.ddev.com/en/stable/users/providers/pantheon/
+
+The exact provider implementation may evolve while the public PLT setup order and safety contract remain stable.

--- a/docs/status.md
+++ b/docs/status.md
@@ -10,7 +10,7 @@ pantheon-local status
 
 A checkout created by `pantheon-local multidev` records non-secret metadata under Git's local metadata directory. Status reads that state and combines it with the current Git checkout state.
 
-Example output:
+Example output after a successful Drupal setup:
 
 ```text
 Pantheon Local Tools status
@@ -27,8 +27,11 @@ URL source:      provider runtime
 Git branch:      feature-a
 Git tracking:    origin/feature-a
 Git state:       clean
-Database source: test
-Files source:    live
+Database source: feature-a
+Files source:    (not recorded)
+Bootstrap status:  complete
+Bootstrap step:    complete
+Bootstrap updated: 2026-09-04T14:30:00Z
 ```
 
 ## Managed and existing checkouts
@@ -36,6 +39,8 @@ Files source:    live
 A checkout is reported as `Managed: yes` when Pantheon Local Tools state exists for it. Existing Git checkouts that were not created by the tool are still useful with `status`: DDEV or Lando is detected from an unambiguous project configuration, while Pantheon-specific values that have not been recorded are shown as `(not recorded)`.
 
 A successful `pantheon-local pull` may create local Pantheon Local Tools state for an existing checkout so the detected provider and data provenance can be retained without modifying application files.
+
+`pantheon-local setup` is intentionally stricter: it requires PLT-managed state containing the authoritative Pantheon environment before it may replace local database data.
 
 Status does not guess when both DDEV and Lando project configuration are present; it reports the provider as ambiguous unless local state already records which provider owns the checkout.
 
@@ -122,6 +127,24 @@ If a component has never been successfully pulled, status displays `(not recorde
 Older checkout state may contain a single legacy `data.source` value from releases before component-specific provenance. Status interprets that value as both database and files without modifying the state file. The next successful component-aware pull migrates that legacy value losslessly.
 
 Provider failures or post-pull Git-safety failures do not update component provenance.
+
+## Drupal bootstrap status
+
+`pantheon-local setup` records its latest orchestration outcome in the same checkout-local PLT state file used for Pantheon identity and data provenance.
+
+Status displays:
+
+```text
+Bootstrap status:  complete|failed|in-progress
+Bootstrap step:    provider-start|composer-install|database-pull|drush-updb|drush-cr|complete
+Bootstrap updated: UTC timestamp
+```
+
+If setup has never run, these values are `(not recorded)`.
+
+The bootstrap fields are troubleshooting state, not a resumable workflow engine. A retry of `pantheon-local setup` starts from provider start again; it does not skip earlier mutating phases because a prior status says they once succeeded.
+
+Successful database provenance remains separate from bootstrap status. For example, if the database pull succeeds and `drush updb` later fails, `Database source` truthfully records the successful database source while `Bootstrap status` reports `failed` and `Bootstrap step` reports `drush-updb`.
 
 ## Safety
 

--- a/libexec/pantheon-local-setup
+++ b/libexec/pantheon-local-setup
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME="pantheon-local"
+SCRIPT_DIR=$(unset CDPATH; cd -- "$(dirname -- "$0")" && pwd)
+PULL="$SCRIPT_DIR/pantheon-local-pull"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  pantheon-local setup [--provider ddev|lando] [--dry-run]
+
+Prepare an existing Pantheon Local Tools-managed Drupal checkout for local
+work using its recorded Pantheon environment. The setup pipeline is:
+
+  provider start
+  -> provider-owned composer install
+  -> guarded database-only pull from the recorded Pantheon environment
+  -> provider-owned drush updb -y
+  -> provider-owned drush cr
+
+Provider behavior:
+  lando  Uses lando start/composer/drush and the existing guarded Lando pull.
+  ddev   Uses ddev start/composer/drush and the existing guarded DDEV Pantheon
+         pull integration.
+
+Safety and mutation boundaries:
+  * The Pantheon environment comes from checkout-local PLT state, never from
+    the Git branch name and never from an inferred Live environment.
+  * Composer runs inside the selected provider. It may access the network and
+    execute project Composer scripts.
+  * The database pull replaces local database data and reuses pantheon-local
+    pull --database-only safeguards/provenance. Files and Git code are not
+    pulled by setup.
+  * updb and cr run only after provider start, Composer, and database pull all
+    succeed. Setup stops on the first failed step and records the failed step.
+  * Setup does not push code/config/data to Pantheon and does not rewrite base
+    DDEV/Lando project configuration.
+  * --dry-run validates local checkout prerequisites and prints the plan only;
+    it does not start a provider, run Composer/Drush, pull data, or change PLT
+    checkout state.
+
+Retry behavior:
+  Fix the reported failure and run pantheon-local setup again. Successful
+  earlier steps may run again; setup never skips ahead based on prior status.
+
+Examples:
+  pantheon-local setup --dry-run
+  pantheon-local setup
+  pantheon-local setup --provider lando
+USAGE
+}
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+validate_environment() {
+  local env=$1
+  [ -n "$env" ] || die 'recorded Pantheon environment cannot be empty'
+  printf '%s\n' "$env" | LC_ALL=C grep -Eq '^[A-Za-z0-9][A-Za-z0-9_-]*$' || \
+    die "recorded Pantheon environment contains unsupported characters: $env"
+}
+
+git_root() {
+  git rev-parse --show-toplevel 2>/dev/null || die 'setup must be run inside a Git checkout'
+}
+
+git_dir_for_root() {
+  local root=$1 git_dir
+  git_dir=$(git -C "$root" rev-parse --git-dir)
+  case "$git_dir" in
+    /*) printf '%s\n' "$git_dir" ;;
+    *) printf '%s/%s\n' "$root" "$git_dir" ;;
+  esac
+}
+
+state_get() {
+  local state=$1 key=$2
+  [ -f "$state" ] || return 1
+  git config --file "$state" --get "$key" 2>/dev/null
+}
+
+provider_config_present() {
+  local root=$1 provider=$2
+  case "$provider" in
+    ddev) [ -f "$root/.ddev/config.yaml" ] ;;
+    lando) [ -f "$root/.lando.yml" ] ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_provider() {
+  local root=$1 has_ddev=false has_lando=false
+  provider_config_present "$root" ddev && has_ddev=true
+  provider_config_present "$root" lando && has_lando=true
+
+  case "$has_ddev:$has_lando" in
+    true:false) printf '%s\n' ddev ;;
+    false:true) printf '%s\n' lando ;;
+    true:true) die 'both DDEV and Lando project configuration were found; choose --provider explicitly' ;;
+    false:false) die 'neither DDEV nor Lando project configuration was found' ;;
+  esac
+}
+
+resolve_provider() {
+  local root=$1 state=$2 override=$3 recorded=''
+
+  if [ -n "$override" ]; then
+    case "$override" in
+      ddev|lando) ;;
+      *) die '--provider must be ddev or lando' ;;
+    esac
+    provider_config_present "$root" "$override" || \
+      die "$override provider selected but its project configuration is missing"
+    printf '%s\n' "$override"
+    return
+  fi
+
+  recorded=$(state_get "$state" local.provider || true)
+  if [ -n "$recorded" ]; then
+    case "$recorded" in
+      ddev|lando)
+        provider_config_present "$root" "$recorded" || \
+          die "recorded provider $recorded no longer has project configuration"
+        printf '%s\n' "$recorded"
+        return
+        ;;
+      *) die "unsupported provider recorded in local state: $recorded" ;;
+    esac
+  fi
+
+  detect_provider "$root"
+}
+
+utc_now() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+record_bootstrap() {
+  local state=$1 status=$2 step=$3 env=$4 provider=$5
+  git config --file "$state" --replace-all bootstrap.status "$status"
+  git config --file "$state" --replace-all bootstrap.step "$step"
+  git config --file "$state" --replace-all bootstrap.environment "$env"
+  git config --file "$state" --replace-all bootstrap.provider "$provider"
+  git config --file "$state" --replace-all bootstrap.updated-at "$(utc_now)"
+}
+
+fail_step() {
+  local state=$1 env=$2 provider=$3 step=$4 label=$5
+  record_bootstrap "$state" failed "$step" "$env" "$provider"
+  die "$label failed; setup stopped at $step. Fix the failure and rerun pantheon-local setup."
+}
+
+run_provider_step() {
+  local root=$1 state=$2 env=$3 provider=$4 step=$5 label=$6
+  shift 6
+  record_bootstrap "$state" in-progress "$step" "$env" "$provider"
+  if ! (cd "$root" && "$provider" "$@"); then
+    fail_step "$state" "$env" "$provider" "$step" "$label"
+  fi
+}
+
+run_pull_step() {
+  local root=$1 state=$2 env=$3 provider=$4
+  record_bootstrap "$state" in-progress database-pull "$env" "$provider"
+  if ! (cd "$root" && "$PULL" "$env" --database-only --provider "$provider"); then
+    fail_step "$state" "$env" "$provider" database-pull 'database pull'
+  fi
+}
+
+print_plan() {
+  local root=$1 site=$2 env=$3 provider=$4
+  printf 'Pantheon Local Tools setup dry-run\n\n'
+  printf 'Directory:   %s\n' "$root"
+  if [ -n "$site" ]; then
+    printf 'Pantheon:    %s.%s\n' "$site" "$env"
+  else
+    printf 'Pantheon:    environment %s (site not recorded)\n' "$env"
+  fi
+  printf 'Provider:    %s\n' "$provider"
+  printf 'Database:    replace local database from %s\n\n' "$env"
+  printf 'Planned steps:\n'
+  printf '  1. %s start\n' "$provider"
+  printf '  2. %s composer install\n' "$provider"
+  printf '  3. pantheon-local pull %s --database-only --provider %s\n' "$env" "$provider"
+  printf '  4. %s drush updb -y\n' "$provider"
+  printf '  5. %s drush cr\n\n' "$provider"
+  printf 'Dry-run only: no provider, Composer, Drush, pull, or state mutation was run.\n'
+}
+
+setup_command() {
+  local provider_override='' dry_run=false root git_dir state env site provider git_state
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --provider)
+        [ "$#" -ge 2 ] || die '--provider requires ddev or lando'
+        provider_override=$2
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      -h|--help|help)
+        usage
+        return
+        ;;
+      --*) die "unknown setup option: $1" ;;
+      *) die 'usage: pantheon-local setup [--provider ddev|lando] [--dry-run]' ;;
+    esac
+  done
+
+  require_command git
+  root=$(git_root)
+  git_dir=$(git_dir_for_root "$root")
+  state="$git_dir/pantheon-local-tools/state"
+  [ -f "$state" ] || \
+    die 'setup requires a Pantheon Local Tools-managed checkout with recorded Pantheon environment state'
+
+  env=$(state_get "$state" pantheon.environment || true)
+  [ -n "$env" ] || \
+    die 'setup requires checkout-local pantheon.environment state; refusing to infer it from the Git branch'
+  validate_environment "$env"
+  site=$(state_get "$state" pantheon.site || true)
+  provider=$(resolve_provider "$root" "$state" "$provider_override")
+
+  [ -f "$root/composer.json" ] || die 'setup requires composer.json at the checkout root'
+  [ -x "$PULL" ] || die "pull module is missing or not executable: $PULL"
+  if [ "$provider" = ddev ]; then
+    [ -f "$root/.ddev/providers/pantheon.yaml" ] || \
+      die 'DDEV Pantheon provider is missing: .ddev/providers/pantheon.yaml'
+  fi
+
+  if [ "$dry_run" = true ]; then
+    print_plan "$root" "$site" "$env" "$provider"
+    return
+  fi
+
+  require_command "$provider"
+  require_command date
+
+  printf 'Preparing Drupal checkout\n\n'
+  printf 'Directory:   %s\n' "$root"
+  printf 'Environment: %s\n' "$env"
+  printf 'Provider:    %s\n\n' "$provider"
+
+  printf 'Step 1/5: starting %s\n' "$provider"
+  run_provider_step "$root" "$state" "$env" "$provider" provider-start 'provider start' start
+
+  printf '\nStep 2/5: installing Composer dependencies inside %s\n' "$provider"
+  run_provider_step "$root" "$state" "$env" "$provider" composer-install 'Composer install' composer install
+
+  printf '\nStep 3/5: refreshing local database from %s\n' "$env"
+  run_pull_step "$root" "$state" "$env" "$provider"
+
+  printf '\nStep 4/5: running Drupal database updates\n'
+  run_provider_step "$root" "$state" "$env" "$provider" drush-updb 'drush updb' drush updb -y
+
+  printf '\nStep 5/5: rebuilding Drupal caches\n'
+  run_provider_step "$root" "$state" "$env" "$provider" drush-cr 'drush cr' drush cr
+
+  record_bootstrap "$state" complete complete "$env" "$provider"
+
+  if [ -n "$(git -C "$root" status --porcelain --untracked-files=normal)" ]; then
+    git_state=modified
+  else
+    git_state=clean
+  fi
+
+  printf '\nDrupal bootstrap complete\n'
+  printf 'Environment: %s\n' "$env"
+  printf 'Provider:    %s\n' "$provider"
+  printf 'Database:    refreshed from %s\n' "$env"
+  printf 'Git state:   %s\n' "$git_state"
+  printf 'Status:      pantheon-local status\n'
+}
+
+setup_command "$@"

--- a/libexec/pantheon-local-status
+++ b/libexec/pantheon-local-status
@@ -13,6 +13,8 @@ Usage:
 Shows local checkout metadata without contacting Pantheon or starting a provider.
 When the selected provider is already running, status may query its read-only
 runtime information to report the provider's authoritative local URL.
+For PLT-managed checkouts, the most recent Drupal bootstrap status/step is also
+reported from checkout-local state.
 USAGE
 }
 
@@ -70,6 +72,7 @@ status_command() {
   local root git_dir state branch tracking git_state dirty managed
   local site env target tag provider provider_base local_name recorded_url local_url url_source provider_config
   local legacy_data_source database_source files_source runtime_url=''
+  local bootstrap_status bootstrap_step bootstrap_updated
 
   require_command git
 
@@ -114,6 +117,9 @@ status_command() {
   legacy_data_source=$(state_get "$state" data.source || true)
   database_source=$(state_get "$state" data.database-source || true)
   files_source=$(state_get "$state" data.files-source || true)
+  bootstrap_status=$(state_get "$state" bootstrap.status || true)
+  bootstrap_step=$(state_get "$state" bootstrap.step || true)
+  bootstrap_updated=$(state_get "$state" bootstrap.updated-at || true)
 
   if [ -z "$database_source" ] && [ -n "$legacy_data_source" ]; then
     database_source=$legacy_data_source
@@ -167,6 +173,9 @@ status_command() {
   [ -n "$local_name" ] || local_name='(not recorded)'
   [ -n "$database_source" ] || database_source='(not recorded)'
   [ -n "$files_source" ] || files_source='(not recorded)'
+  [ -n "$bootstrap_status" ] || bootstrap_status='(not recorded)'
+  [ -n "$bootstrap_step" ] || bootstrap_step='(not recorded)'
+  [ -n "$bootstrap_updated" ] || bootstrap_updated='(not recorded)'
 
   printf 'Pantheon Local Tools status\n\n'
   printf 'Directory:       %s\n' "$root"
@@ -183,6 +192,9 @@ status_command() {
   printf 'Git state:       %s\n' "$git_state"
   printf 'Database source: %s\n' "$database_source"
   printf 'Files source:    %s\n' "$files_source"
+  printf 'Bootstrap status:  %s\n' "$bootstrap_status"
+  printf 'Bootstrap step:    %s\n' "$bootstrap_step"
+  printf 'Bootstrap updated: %s\n' "$bootstrap_updated"
 }
 
 case "${1:-}" in

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -43,6 +43,7 @@ install -m 0755 "$REPO_ROOT/libexec/pantheon-local-core" "$APP_ROOT/libexec/pant
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-config-profile" "$APP_ROOT/libexec/pantheon-local-config-profile"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-provider-url" "$APP_ROOT/libexec/pantheon-local-provider-url"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-pull" "$APP_ROOT/libexec/pantheon-local-pull"
+install -m 0755 "$REPO_ROOT/libexec/pantheon-local-setup" "$APP_ROOT/libexec/pantheon-local-setup"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-status" "$APP_ROOT/libexec/pantheon-local-status"
 install -m 0644 "$VERSION_FILE" "$APP_ROOT/VERSION"
 install -m 0644 "$REPO_ROOT/LICENSE" "$DOC_ROOT/copyright"
@@ -61,7 +62,8 @@ Depends: bash, git
 Homepage: https://github.com/zevarix/pantheon-local-tools
 Description: Provider-neutral local development helpers for Pantheon
  Pantheon Local Tools provides a consistent CLI for Pantheon multidev
- checkout, data pull, and local status workflows with DDEV and Lando.
+ checkout, Drupal bootstrap, data pull, and local status workflows with DDEV
+ and Lando.
 EOF
 
 chmod 0755 "$CONTROL_ROOT"

--- a/tests/test-debian-package.sh
+++ b/tests/test-debian-package.sh
@@ -31,6 +31,7 @@ dpkg-deb -x "$PACKAGE" "$EXTRACT"
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-config-profile" ] || fail 'packaged tag-profile module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-provider-url" ] || fail 'packaged URL module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-pull" ] || fail 'packaged pull module is missing or not executable'
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-setup" ] || fail 'packaged setup module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-status" ] || fail 'packaged status module is missing or not executable'
 [ -f "$EXTRACT/usr/lib/pantheon-local-tools/VERSION" ] || fail 'packaged VERSION is missing'
 [ -L "$EXTRACT/usr/bin/pantheon-local" ] || fail 'packaged command link is missing'
@@ -51,6 +52,7 @@ assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config get provider)" 'ddev'
 "$EXTRACT/usr/bin/pantheon-local" config tag profile set 'Package Example' config-path config/sync
 assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config tag profile get 'Package Example' config-strategy)" 'full-export'
 assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config tag profile get 'Package Example' config-path)" 'config/sync'
+"$EXTRACT/usr/bin/pantheon-local" setup --help | grep -F 'pantheon-local setup' >/dev/null 2>&1 || fail 'packaged setup help is unavailable'
 
 # Packaging must not ship user state, provider project configuration, or credentials.
 if find "$EXTRACT" -type f -o -type l | grep -E '/\.config/|/\.lando|/\.ddev|pantheon-local-tools/state|machine-token' >/dev/null 2>&1; then

--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -68,7 +68,7 @@ setup_help=$(bash "$CLI" setup --help)
 assert_contains "$setup_help" 'pantheon-local setup [--provider ddev|lando] [--dry-run]'
 assert_contains "$setup_help" 'provider-owned composer install'
 assert_contains "$setup_help" 'replaces local database data'
-assert_contains "$setup_help" 'never from the Git branch name'
+assert_contains "$setup_help" 'checkout-local PLT state'
 assert_contains "$setup_help" 'Setup stops on the first failed step'
 assert_contains "$setup_help" 'Fix the reported failure and run pantheon-local setup again.'
 

--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -30,6 +30,7 @@ for expected in \
   'config-strategy  full-export or overlay-delta' \
   'config-path      Relative project configuration path such as config/sync' \
   'pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]' \
+  'pantheon-local setup [--provider ddev|lando] [--dry-run]' \
   'pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]' \
   'pantheon-local status' \
   'pantheon-local version' \
@@ -37,6 +38,7 @@ for expected in \
   'auto   Detect from project configuration after checkout' \
   "pantheon-local config tag profile set 'Example Group' config-strategy full-export" \
   'pantheon-local multidev example.feature --dry-run' \
+  'pantheon-local setup --dry-run' \
   'pantheon-local pull test --database-only'
 do
   assert_contains "$help_output" "$expected"
@@ -62,6 +64,14 @@ assert_contains "$profile_help" 'Setting a profile property never creates a tag 
 multidev_help=$(bash "$CLI" multidev --help)
 assert_contains "$multidev_help" 'pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]'
 
+setup_help=$(bash "$CLI" setup --help)
+assert_contains "$setup_help" 'pantheon-local setup [--provider ddev|lando] [--dry-run]'
+assert_contains "$setup_help" 'provider-owned composer install'
+assert_contains "$setup_help" 'replaces local database data'
+assert_contains "$setup_help" 'never from the Git branch name'
+assert_contains "$setup_help" 'Setup stops on the first failed step'
+assert_contains "$setup_help" 'Fix the reported failure and run pantheon-local setup again.'
+
 pull_help=$(bash "$CLI" pull --help)
 assert_contains "$pull_help" 'pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]'
 assert_contains "$pull_help" 'without changing checked-out Git code'
@@ -69,5 +79,6 @@ assert_contains "$pull_help" 'without changing checked-out Git code'
 status_help=$(bash "$CLI" status --help)
 assert_contains "$status_help" 'pantheon-local status'
 assert_contains "$status_help" 'without contacting Pantheon or starting a provider'
+assert_contains "$status_help" 'Drupal bootstrap status/step'
 
 printf 'help tests passed\n'

--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -90,12 +90,14 @@ FORMULA_CLI="$PREFIX/bin/pantheon-local"
 [ -x "$PREFIX/libexec/libexec/pantheon-local-config-profile" ] || fail 'Homebrew tag-profile module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-provider-url" ] || fail 'Homebrew provider URL module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-pull" ] || fail 'Homebrew pull module is missing'
+[ -x "$PREFIX/libexec/libexec/pantheon-local-setup" ] || fail 'Homebrew setup module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-status" ] || fail 'Homebrew status module is missing'
 [ -f "$PREFIX/libexec/VERSION" ] || fail 'Homebrew VERSION is missing'
 
 expected="pantheon-local $VERSION"
 assert_eq "$("$FORMULA_CLI" --version)" "$expected"
 assert_eq "$("$FORMULA_CLI" version)" "$expected"
+"$FORMULA_CLI" setup --help | grep -F 'pantheon-local setup' >/dev/null 2>&1 || fail 'Homebrew setup help is unavailable'
 
 TEST_HOME="$TMP_ROOT/home"
 CALLER_CONFIG="$TMP_ROOT/caller-config"

--- a/tests/test-release-artifacts.sh
+++ b/tests/test-release-artifacts.sh
@@ -45,6 +45,7 @@ tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/VERSION" >/dev/null 2>&1 || fail 'VER
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/bin/pantheon-local" >/dev/null 2>&1 || fail 'CLI missing from source archive'
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-core" >/dev/null 2>&1 || fail 'core module missing from source archive'
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-config-profile" >/dev/null 2>&1 || fail 'tag-profile module missing from source archive'
+tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-setup" >/dev/null 2>&1 || fail 'setup module missing from source archive'
 if tar -tzf "$SOURCE_ONE" | grep -E '/\.git(/|$)|/dist(/|$)|/\.agents(/|$)' >/dev/null 2>&1; then
   fail 'source archive contains repository-local/private build state'
 fi
@@ -54,6 +55,7 @@ mkdir -p "$EXTRACT"
 tar -xzf "$SOURCE_ONE" -C "$EXTRACT"
 expected="pantheon-local $VERSION"
 assert_eq "$(bash "$EXTRACT/$PREFIX/bin/pantheon-local" --version)" "$expected"
+bash "$EXTRACT/$PREFIX/bin/pantheon-local" setup --help | grep -F 'pantheon-local setup' >/dev/null 2>&1 || fail 'source archive setup help is unavailable'
 
 if command -v dpkg-deb >/dev/null 2>&1; then
   DEB_NAME="pantheon-local-tools_${VERSION}_all.deb"

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -111,7 +111,7 @@ DRY_STATE=$(state_path "$DRY")
 rm -f "$MOCK_LOG"
 dry_output=$(cd "$DRY" && bash "$CLI" setup --dry-run)
 assert_contains "$dry_output" 'Pantheon:    example-site.phase1'
-assert_contains "$dry_output" 'lando pull phase1 --database-only --provider lando'
+assert_contains "$dry_output" 'pantheon-local pull phase1 --database-only --provider lando'
 assert_contains "$dry_output" 'Dry-run only:'
 [ ! -e "$MOCK_LOG" ] || fail 'dry-run executed a provider command'
 assert_config_missing "$DRY_STATE" bootstrap.status

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+CLI=${CLI:-"$REPO_ROOT/bin/pantheon-local"}
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+MOCK_BIN="$TMP_ROOT/bin"
+MOCK_LOG="$TMP_ROOT/provider.log"
+mkdir -p "$MOCK_BIN"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
+assert_file_contains() { grep -F "$2" "$1" >/dev/null 2>&1 || fail "expected $1 to contain [$2]"; }
+assert_file_not_contains() { if [ -f "$1" ] && grep -F "$2" "$1" >/dev/null 2>&1; then fail "expected $1 not to contain [$2]"; fi; }
+assert_line() {
+  local file=$1 number=$2 expected=$3 actual
+  actual=$(sed -n "${number}p" "$file")
+  [ "$actual" = "$expected" ] || fail "expected line $number [$expected], got [$actual]"
+}
+assert_config() {
+  local file=$1 key=$2 expected=$3 actual
+  actual=$(git config --file "$file" --get "$key" 2>/dev/null || true)
+  [ "$actual" = "$expected" ] || fail "expected $key=$expected in $file, got [$actual]"
+}
+assert_config_missing() {
+  local file=$1 key=$2
+  if [ -f "$file" ] && git config --file "$file" --get "$key" >/dev/null 2>&1; then
+    fail "expected $key to be absent from $file"
+  fi
+}
+
+cat > "$MOCK_BIN/lando" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+line='lando'
+for arg in "$@"; do line="$line|$arg"; done
+printf '%s\n' "$line" >> "${MOCK_LOG:?}"
+if [ -n "${MOCK_FAIL_MATCH:-}" ]; then
+  case "$line" in *"$MOCK_FAIL_MATCH"*) exit 9 ;; esac
+fi
+MOCK
+chmod +x "$MOCK_BIN/lando"
+
+cat > "$MOCK_BIN/ddev" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+line='ddev'
+for arg in "$@"; do line="$line|$arg"; done
+printf '%s\n' "$line" >> "${MOCK_LOG:?}"
+if [ -n "${MOCK_FAIL_MATCH:-}" ]; then
+  case "$line" in *"$MOCK_FAIL_MATCH"*) exit 9 ;; esac
+fi
+MOCK
+chmod +x "$MOCK_BIN/ddev"
+
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_LOG
+
+create_repo() {
+  local path=$1 provider=$2 env=$3
+  mkdir -p "$path"
+  git -C "$path" init -q
+  git -C "$path" config user.name 'Test User'
+  git -C "$path" config user.email 'test@example.com'
+  printf 'fixture\n' > "$path/README.md"
+  printf '{"name":"example/site"}\n' > "$path/composer.json"
+
+  case "$provider" in
+    lando)
+      printf 'name: example-site\nrecipe: pantheon\n' > "$path/.lando.yml"
+      ;;
+    ddev)
+      mkdir -p "$path/.ddev/providers"
+      printf 'name: example-site\ntype: drupal11\n' > "$path/.ddev/config.yaml"
+      printf '# Pantheon provider fixture\n' > "$path/.ddev/providers/pantheon.yaml"
+      ;;
+    *) fail "unknown provider fixture: $provider" ;;
+  esac
+
+  git -C "$path" add .
+  git -C "$path" commit -qm 'Create setup fixture'
+  git -C "$path" branch -M misleading-branch
+
+  mkdir -p "$path/.git/pantheon-local-tools"
+  git config --file "$path/.git/pantheon-local-tools/state" pantheon.site example-site
+  git config --file "$path/.git/pantheon-local-tools/state" pantheon.environment "$env"
+  git config --file "$path/.git/pantheon-local-tools/state" local.provider "$provider"
+}
+
+state_path() {
+  printf '%s/.git/pantheon-local-tools/state\n' "$1"
+}
+
+reset_log() {
+  : > "$MOCK_LOG"
+}
+
+assert_contains "$(bash "$CLI" --help)" 'pantheon-local setup [--provider ddev|lando] [--dry-run]'
+setup_help=$(bash "$CLI" setup --help)
+assert_contains "$setup_help" 'provider-owned composer install'
+assert_contains "$setup_help" 'replaces local database data'
+assert_contains "$setup_help" 'stops on the first failed step'
+assert_contains "$setup_help" 'never from the Git branch name'
+assert_contains "$setup_help" 'Fix the reported failure and run pantheon-local setup again.'
+
+# Dry-run validates and reports the exact managed environment without any mutation.
+DRY="$TMP_ROOT/dry"
+create_repo "$DRY" lando phase1
+DRY_STATE=$(state_path "$DRY")
+rm -f "$MOCK_LOG"
+dry_output=$(cd "$DRY" && bash "$CLI" setup --dry-run)
+assert_contains "$dry_output" 'Pantheon:    example-site.phase1'
+assert_contains "$dry_output" 'lando pull phase1 --database-only --provider lando'
+assert_contains "$dry_output" 'Dry-run only:'
+[ ! -e "$MOCK_LOG" ] || fail 'dry-run executed a provider command'
+assert_config_missing "$DRY_STATE" bootstrap.status
+assert_config_missing "$DRY_STATE" data.database-source
+
+# Lando happy path follows the required order and pulls the recorded environment, not the branch.
+LANDO="$TMP_ROOT/lando"
+create_repo "$LANDO" lando phase1
+LANDO_STATE=$(state_path "$LANDO")
+reset_log
+lando_output=$(cd "$LANDO" && bash "$CLI" setup)
+assert_line "$MOCK_LOG" 1 'lando|start'
+assert_line "$MOCK_LOG" 2 'lando|composer|install'
+assert_line "$MOCK_LOG" 3 'lando|pull|--code=none|--database=phase1|--files=none'
+assert_line "$MOCK_LOG" 4 'lando|drush|updb|-y'
+assert_line "$MOCK_LOG" 5 'lando|drush|cr'
+assert_contains "$lando_output" 'Drupal bootstrap complete'
+assert_contains "$lando_output" 'Environment: phase1'
+assert_config "$LANDO_STATE" data.database-source phase1
+assert_config_missing "$LANDO_STATE" data.files-source
+assert_config "$LANDO_STATE" bootstrap.status complete
+assert_config "$LANDO_STATE" bootstrap.step complete
+assert_config "$LANDO_STATE" bootstrap.environment phase1
+assert_config "$LANDO_STATE" bootstrap.provider lando
+[ -n "$(git config --file "$LANDO_STATE" --get bootstrap.updated-at)" ] || fail 'bootstrap timestamp was not recorded'
+status_output=$(cd "$LANDO" && bash "$CLI" status)
+assert_contains "$status_output" 'Bootstrap status:  complete'
+assert_contains "$status_output" 'Bootstrap step:    complete'
+
+# DDEV uses DDEV-owned Composer/Drush and the existing Pantheon database-only pull contract.
+DDEV="$TMP_ROOT/ddev"
+create_repo "$DDEV" ddev feature1
+DDEV_STATE=$(state_path "$DDEV")
+reset_log
+(cd "$DDEV" && bash "$CLI" setup >/dev/null)
+assert_line "$MOCK_LOG" 1 'ddev|start'
+assert_line "$MOCK_LOG" 2 'ddev|composer|install'
+assert_line "$MOCK_LOG" 3 'ddev|pull|pantheon|--environment=DDEV_PANTHEON_SITE=example-site,DDEV_PANTHEON_ENVIRONMENT=feature1|--skip-files|-y'
+assert_line "$MOCK_LOG" 4 'ddev|drush|updb|-y'
+assert_line "$MOCK_LOG" 5 'ddev|drush|cr'
+assert_config "$DDEV_STATE" data.database-source feature1
+assert_config_missing "$DDEV_STATE" data.files-source
+assert_config "$DDEV_STATE" bootstrap.status complete
+
+# Known preflight failures happen before the provider starts.
+UNMANAGED="$TMP_ROOT/unmanaged"
+create_repo "$UNMANAGED" lando feature2
+rm -rf "$UNMANAGED/.git/pantheon-local-tools"
+reset_log
+if (cd "$UNMANAGED" && bash "$CLI" setup >/dev/null 2>&1); then
+  fail 'setup accepted a checkout without recorded Pantheon environment state'
+fi
+[ ! -s "$MOCK_LOG" ] || fail 'unmanaged checkout failure started the provider'
+
+DDEV_MISSING="$TMP_ROOT/ddev-missing"
+create_repo "$DDEV_MISSING" ddev feature3
+rm "$DDEV_MISSING/.ddev/providers/pantheon.yaml"
+reset_log
+if (cd "$DDEV_MISSING" && bash "$CLI" setup >/dev/null 2>&1); then
+  fail 'setup accepted DDEV without the Pantheon provider integration'
+fi
+[ ! -s "$MOCK_LOG" ] || fail 'missing DDEV Pantheon integration started the provider'
+
+COMPOSER_MISSING="$TMP_ROOT/composer-missing"
+create_repo "$COMPOSER_MISSING" lando feature4
+rm "$COMPOSER_MISSING/composer.json"
+reset_log
+if (cd "$COMPOSER_MISSING" && bash "$CLI" setup >/dev/null 2>&1); then
+  fail 'setup accepted a checkout without composer.json'
+fi
+[ ! -s "$MOCK_LOG" ] || fail 'missing composer.json started the provider'
+
+# Every mutating failure records the exact failed step and prevents later steps.
+START_FAIL="$TMP_ROOT/start-fail"
+create_repo "$START_FAIL" lando fail1
+START_STATE=$(state_path "$START_FAIL")
+reset_log
+export MOCK_FAIL_MATCH='lando|start'
+if (cd "$START_FAIL" && bash "$CLI" setup >/dev/null 2>&1); then fail 'provider start failure unexpectedly succeeded'; fi
+unset MOCK_FAIL_MATCH
+assert_line "$MOCK_LOG" 1 'lando|start'
+assert_file_not_contains "$MOCK_LOG" 'lando|composer|install'
+assert_config "$START_STATE" bootstrap.status failed
+assert_config "$START_STATE" bootstrap.step provider-start
+assert_config_missing "$START_STATE" data.database-source
+
+COMPOSER_FAIL="$TMP_ROOT/composer-fail"
+create_repo "$COMPOSER_FAIL" lando fail2
+COMPOSER_STATE=$(state_path "$COMPOSER_FAIL")
+reset_log
+export MOCK_FAIL_MATCH='lando|composer|install'
+if (cd "$COMPOSER_FAIL" && bash "$CLI" setup >/dev/null 2>&1); then fail 'Composer failure unexpectedly succeeded'; fi
+unset MOCK_FAIL_MATCH
+assert_file_contains "$MOCK_LOG" 'lando|start'
+assert_file_contains "$MOCK_LOG" 'lando|composer|install'
+assert_file_not_contains "$MOCK_LOG" 'lando|pull|'
+assert_file_not_contains "$MOCK_LOG" 'lando|drush|updb|-y'
+assert_config "$COMPOSER_STATE" bootstrap.status failed
+assert_config "$COMPOSER_STATE" bootstrap.step composer-install
+assert_config_missing "$COMPOSER_STATE" data.database-source
+
+PULL_FAIL="$TMP_ROOT/pull-fail"
+create_repo "$PULL_FAIL" lando fail3
+PULL_STATE=$(state_path "$PULL_FAIL")
+reset_log
+export MOCK_FAIL_MATCH='lando|pull|'
+if (cd "$PULL_FAIL" && bash "$CLI" setup >/dev/null 2>&1); then fail 'database pull failure unexpectedly succeeded'; fi
+unset MOCK_FAIL_MATCH
+assert_file_contains "$MOCK_LOG" 'lando|pull|--code=none|--database=fail3|--files=none'
+assert_file_not_contains "$MOCK_LOG" 'lando|drush|updb|-y'
+assert_file_not_contains "$MOCK_LOG" 'lando|drush|cr'
+assert_config "$PULL_STATE" bootstrap.status failed
+assert_config "$PULL_STATE" bootstrap.step database-pull
+assert_config_missing "$PULL_STATE" data.database-source
+
+UPDB_FAIL="$TMP_ROOT/updb-fail"
+create_repo "$UPDB_FAIL" lando fail4
+UPDB_STATE=$(state_path "$UPDB_FAIL")
+reset_log
+export MOCK_FAIL_MATCH='lando|drush|updb|-y'
+if (cd "$UPDB_FAIL" && bash "$CLI" setup >/dev/null 2>&1); then fail 'updb failure unexpectedly succeeded'; fi
+unset MOCK_FAIL_MATCH
+assert_file_contains "$MOCK_LOG" 'lando|drush|updb|-y'
+assert_file_not_contains "$MOCK_LOG" 'lando|drush|cr'
+assert_config "$UPDB_STATE" data.database-source fail4
+assert_config "$UPDB_STATE" bootstrap.status failed
+assert_config "$UPDB_STATE" bootstrap.step drush-updb
+
+CR_FAIL="$TMP_ROOT/cr-fail"
+create_repo "$CR_FAIL" lando fail5
+CR_STATE=$(state_path "$CR_FAIL")
+reset_log
+export MOCK_FAIL_MATCH='lando|drush|cr'
+if (cd "$CR_FAIL" && bash "$CLI" setup >/dev/null 2>&1); then fail 'cache rebuild failure unexpectedly succeeded'; fi
+unset MOCK_FAIL_MATCH
+assert_file_contains "$MOCK_LOG" 'lando|drush|updb|-y'
+assert_file_contains "$MOCK_LOG" 'lando|drush|cr'
+assert_config "$CR_STATE" data.database-source fail5
+assert_config "$CR_STATE" bootstrap.status failed
+assert_config "$CR_STATE" bootstrap.step drush-cr
+
+printf 'setup tests passed\n'

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -101,7 +101,7 @@ setup_help=$(bash "$CLI" setup --help)
 assert_contains "$setup_help" 'provider-owned composer install'
 assert_contains "$setup_help" 'replaces local database data'
 assert_contains "$setup_help" 'stops on the first failed step'
-assert_contains "$setup_help" 'never from the Git branch name'
+assert_contains "$setup_help" 'checkout-local PLT state'
 assert_contains "$setup_help" 'Fix the reported failure and run pantheon-local setup again.'
 
 # Dry-run validates and reports the exact managed environment without any mutation.


### PR DESCRIPTION
## Summary

- add checkout-local `pantheon-local setup [--provider ddev|lando] [--dry-run]`
- execute provider start → provider-owned Composer install → existing guarded database-only pull → `drush updb -y` → `drush cr`
- source the Pantheon environment only from checkout-local PLT state rather than Git branch inference
- fail before mutation on known local prerequisites and stop immediately on the first mutating step failure
- record bootstrap status/step/environment/provider/timestamp in `.git/pantheon-local-tools/state` and surface it through `pantheon-local status`
- add deterministic Lando/DDEV happy-path, preflight, and stop-on-failure tests plus Debian/Homebrew/source-release coverage
- document setup, status/provenance semantics, compatibility guarantees, mutation/retry boundaries, and current Lando/DDEV provider references

## Safety

`setup` is explicitly local and mutating: provider startup may build containers, Composer may use the network and execute project scripts, the database-only pull replaces local database data, and Drush updates the local database/cache. It never pushes code/config/data to Pantheon, never pulls Git code or files, never exports Drupal config, and never rewrites provider-owned base configuration.

The database source is the checkout's recorded `pantheon.environment`; setup refuses to infer it from the Git branch or substitute Live. `multidev --start` remains provider-start only.

`--dry-run` performs local preflight and prints the exact plan without provider/Composer/Drush/pull/state mutation.

## Validation

Focused regression coverage proves:

- Lando and DDEV command ordering and provider ownership
- use of recorded Pantheon environment despite a deliberately misleading Git branch name
- reuse of existing database-only pull/provenance semantics
- no files provenance from setup
- unmanaged/missing-provider/missing-Composer preflight refusal before provider start
- no continuation after provider, Composer, pull, `updb`, or `cr` failure
- truthful bootstrap failure/completion state and status reporting
- global/focused help contracts
- Debian, Homebrew, and source-release module distribution

Repository CI is the execution authority for Bash syntax, ShellCheck, the full shell integration suite on Ubuntu/macOS, packaging, APT publication, and published-APT validation.

Closes #69