### PR TITLE
Harden public repository metadata hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,26 +7,26 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a problem. Do not include credentials, tokens, SSH keys, or other secrets.
+        Thanks for taking the time to report a problem. This is a public repository. Do not include credentials, tokens, SSH keys, employer/client/organization names, internal project or site identifiers, private environment names, machine/user names, local paths, or other private data. Replace real identifiers with generic examples.
   - type: textarea
     id: summary
     attributes:
       label: What happened?
-      description: Describe the problem and what you expected instead.
+      description: Describe the problem and what you expected instead using generic public-safe identifiers.
     validations:
       required: true
   - type: textarea
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: Include the smallest reliable set of steps and commands that reproduces the issue.
+      description: Include the smallest reliable set of sanitized steps and commands that reproduces the issue.
     validations:
       required: true
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Include OS, shell, WSL distribution/version when applicable, local provider and version, Terminus version, and tool version when known.
+      description: Include OS, shell, WSL distribution/version when applicable, local provider and version, Terminus version, and tool version when known. Do not include private site/environment names or local paths.
       placeholder: |
         OS:
         WSL distribution/version (if applicable):
@@ -41,12 +41,14 @@ body:
     id: output
     attributes:
       label: Relevant output
-      description: Paste sanitized output or logs. Remove credentials and private data first.
+      description: Paste sanitized output or logs. Replace real organization, project, site, environment, machine, username, and path values with generic placeholders first.
       render: shell
   - type: checkboxes
     id: safety
     attributes:
-      label: Safety check
+      label: Public-repository safety check
       options:
         - label: I removed credentials, tokens, keys, passwords, and other secrets from this report.
+          required: true
+        - label: I replaced employer-, client-, organization-, institution-, internal-project-, private-site-, environment-, machine-, username-, directory-, and local-path identifiers with generic public-safe examples.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,2 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,27 +4,38 @@ title: "[Feature]: "
 labels:
   - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a public repository. Describe workflows with generic public-safe names only. Do not include employer/client/organization names, internal project or site identifiers, private environment names, machine/user names, local paths, or copied private configuration.
   - type: textarea
     id: problem
     attributes:
       label: Problem or workflow
-      description: What problem are you trying to solve?
+      description: What problem are you trying to solve? Replace real identifiers with generic examples.
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
       label: Proposed behavior
-      description: Describe the behavior you would like to see.
+      description: Describe the behavior you would like to see using generic public-safe examples only.
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Optional. Describe workarounds or alternative designs you considered.
+      description: Optional. Describe workarounds or alternative designs you considered without exposing private/internal identifiers.
   - type: textarea
     id: safety
     attributes:
       label: Safety or compatibility considerations
-      description: Note any remote writes, destructive operations, path handling, platform compatibility, or configuration concerns.
+      description: Note any remote writes, destructive operations, path handling, platform compatibility, configuration concerns, or public-repository sanitization considerations.
+  - type: checkboxes
+    id: public_safety
+    attributes:
+      label: Public-repository safety check
+      options:
+        - label: I replaced employer-, client-, organization-, institution-, internal-project-, private-site-, environment-, machine-, username-, directory-, and local-path identifiers with generic public-safe examples.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 
-Describe the change and why it is needed.
+Describe the change and why it is needed using generic public-safe examples only.
 
 ## Validation
 
@@ -8,8 +8,9 @@ Describe the change and why it is needed.
 - [ ] I added or updated tests where appropriate.
 - [ ] I updated user-facing documentation where appropriate.
 - [ ] I did not add credentials, tokens, machine-specific paths, or other secrets.
+- [ ] I sanitized commit messages, PR text, examples, fixtures, logs, screenshots, and documentation so they contain no employer-, client-, organization-, institution-, internal-project-, private-site-, environment-, machine-, username-, directory-, or local-path identifiers.
 - [ ] Destructive or remote-write behavior remains explicit and fail-safe.
 
 ## Notes for reviewers
 
-Call out any tradeoffs, compatibility concerns, or follow-up work that would help review this change.
+Call out any tradeoffs, compatibility concerns, or follow-up work that would help review this change. Keep all examples generic and public-safe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ Thanks for helping improve Pantheon Local Tools.
 - For behavior changes, prefer opening an issue first so the intended workflow can be agreed on before implementation.
 - Keep changes focused. Small pull requests are easier to review and safer to merge.
 
+## Public repository hygiene
+
+Pantheon Local Tools is a public repository. Repository code, commit messages, issues, pull requests, comments, examples, fixtures, logs, screenshots, and documentation must use generic public-safe identifiers.
+
+Do not publish employer-, client-, organization-, institution-, internal-project-, private-site-, environment-, machine-, username-, directory-, or local-path identifiers. Replace real names with generic examples such as `example-site`, `Example Group`, `config/site-overrides`, or documented placeholders such as `SITE.ENV`.
+
+Before opening or updating any public issue, pull request, or comment, sanitize copied commands, logs, paths, screenshots, configuration, and prose. If a real internal workflow is needed to validate behavior, keep the private evidence outside this repository and record only the generic product contract here.
+
 ## Development setup
 
 The command-line tooling targets macOS, Linux, and Windows through WSL/WSL2. Native PowerShell and Command Prompt are not initial targets.
@@ -33,7 +41,8 @@ Never add machine tokens or other credentials to tests, fixtures, documentation 
 5. Update documentation when user-visible behavior changes.
 6. When changing provider behavior, validate the affected provider and avoid regressions in the other supported provider.
 7. When changing portable shell behavior, consider macOS, Linux, and WSL path/shell semantics.
-8. Open a pull request against `main` and explain what changed, why, and how it was tested.
+8. Sanitize issue/PR text, commits, examples, fixtures, logs, screenshots, and documentation so they contain only generic public-safe identifiers.
+9. Open a pull request against `main` and explain what changed, why, and how it was tested.
 
 The repository uses squash merging so each reviewed pull request becomes one canonical integration commit.
 
@@ -44,7 +53,7 @@ For public repository work, maintainers should use a GitHub noreply address for 
 This project interacts with developer environments and Pantheon sites. Changes must fail safely.
 
 - Do not overwrite an existing checkout without explicit user action.
-- Do not embed credentials, tokens, machine-specific paths, organization-specific Pantheon Tags, or private naming conventions.
+- Do not embed credentials, tokens, machine-specific paths, organization-specific Pantheon Tags, private naming conventions, or other internal identifiers.
 - Treat remote writes, destructive local operations, and environment start/rebuild operations as explicit actions rather than hidden side effects.
 - Prefer documented Terminus, DDEV, and Lando interfaces over scraping or guessing implementation details.
 - Do not make shared Pantheon logic depend directly on one local provider.


### PR DESCRIPTION
## Summary

Tighten the public-repository safety contract so issues, pull requests, comments, commits, examples, fixtures, logs, screenshots, documentation, and copied workflow material use generic public-safe identifiers only.

- document the public metadata hygiene rule in `CONTRIBUTING.md`
- add explicit sanitization checks to the pull request template
- add public-safety warnings and required sanitization acknowledgements to bug and feature issue forms
- disable blank issues so new reports go through the sanitization guidance

## Validation

- reviewed all changed files for generic/public-safe wording
- no product behavior changes
- no credentials, private paths, organization-specific names, or internal project/site identifiers added

## Safety

This change only hardens repository contribution metadata and templates. It does not alter Pantheon, provider, checkout, setup, pull, readiness, or remote-write behavior.