### PR TITLE
Add fail-closed overlay delta readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The project follows Semantic Versioning for its public command/configuration con
 - Added checkout-local `pantheon-local setup [--provider ddev|lando] [--dry-run]` for provider-aware Drupal bootstrap using the checkout's recorded Pantheon environment.
 - Added bootstrap status/step/timestamp reporting to checkout-local state and `pantheon-local status`.
 - Added `pantheon-local readiness [--provider ddev|lando]` for read-oriented `full-export` Drupal configuration inspection using the recorded Tag profile, configured config path, provider-owned Drush, Config Ignore module-state reporting, and final Git state.
+- Added fail-closed `overlay-delta` readiness reporting that validates the configured protected partial path and Git state without invoking a provider/Drush or treating file count/missing YAML as drift.
 
 ### Changed
 
@@ -21,6 +22,7 @@ The project follows Semantic Versioning for its public command/configuration con
 - Debian/Homebrew/release packaging coverage now includes the Tag-profile, Drupal-setup, and readiness command modules.
 - Drupal setup now composes the existing guarded database-only pull after provider-owned Composer install, then runs `drush updb -y` and `drush cr`, stopping on the first failed step.
 - Full-export readiness now verifies the configured profile path against Drupal's runtime config-sync path, reports configuration differences as review states rather than automatically exporting, and fails if inspection itself changes Git-visible source state.
+- Readiness now rejects configured directories that escape the Git project root through filesystem links. Overlay-delta reports `Owning validation: unavailable` / `Readiness: unavailable` and exits nonzero until a reliable non-destructive owning validation mechanism exists.
 
 ## 0.1.1 — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,15 @@ pantheon-local setup
 
 Setup starts the selected provider, runs Composer inside that provider, reuses the guarded database-only pull from the checkout's recorded Pantheon environment, then runs `drush updb -y` and `drush cr`. See [`docs/setup.md`](docs/setup.md) for its mutation and retry contract.
 
-For a checkout whose recorded Tag uses a complete `full-export` profile, inspect Drupal configuration readiness without exporting anything:
+Inspect the recorded Tag profile's configuration boundary without exporting anything:
 
 ```bash
 pantheon-local readiness
 ```
 
-Readiness uses the profile's configured path, verifies it against Drupal's runtime config-sync path, reports `drush config:status`, Config Ignore module state when detectable, and the Git working tree. Differences are review states rather than automatic failures, and no `drush cex` / `config:export` is performed. See [`docs/readiness.md`](docs/readiness.md).
+For `full-export`, readiness uses the configured path, verifies it against Drupal's runtime config-sync path, reports `drush config:status`, Config Ignore module state when detectable, and the Git working tree. Differences are review states rather than automatic failures.
+
+For `overlay-delta`, readiness validates that the configured protected partial path exists and remains inside the project root, reports Git state, performs no provider/Drush call, and exits nonzero with `Owning validation: unavailable` rather than inventing drift/readiness semantics. Missing YAML, directory size, and file count are not treated as drift. Neither strategy performs `drush cex` / `config:export`. See [`docs/readiness.md`](docs/readiness.md).
 
 ## Commands
 
@@ -200,15 +202,17 @@ See [`docs/setup.md`](docs/setup.md) for provider mappings, preflight, failure/r
 
 ### Drupal configuration readiness
 
-`pantheon-local readiness` is a standalone, read-oriented inspection for the current PLT-managed checkout. The initial implementation supports only profiles whose recorded Tag declares `config-strategy=full-export` plus a configured `config-path`.
+`pantheon-local readiness` is a standalone, strategy-aware inspection for the current PLT-managed checkout. The recorded Tag must declare either `config-strategy=full-export` or `config-strategy=overlay-delta` plus a configured `config-path`.
 
-Readiness does not start/rebuild the provider. It uses provider-owned Drush to verify that Drupal's runtime config-sync path corresponds to the configured profile path, inspect active-versus-exported configuration differences, and detect whether Config Ignore is enabled when that module-state query is available. It also compares Git state before and after inspection so a supposedly read-only inspection cannot silently mutate source.
+For `full-export`, readiness does not start/rebuild the provider. It uses provider-owned Drush to verify that Drupal's runtime config-sync path corresponds to the configured profile path, inspect active-versus-exported configuration differences, and detect whether Config Ignore is enabled when that module-state query is available. It also compares Git state before and after delegated inspection so a supposedly read-only command cannot silently mutate source.
 
-Synchronized configuration and a clean tree report `ready`. Configuration differences and a pre-existing modified tree report review-required states but still exit successfully when the inspection itself is complete. Provider/Drush failures, path mismatch, unsupported/incomplete profiles, or Git changes caused during inspection fail nonzero.
+Synchronized full-export configuration and a clean tree report `ready`. Configuration differences and a pre-existing modified tree report review-required states but still exit successfully when the inspection itself is complete. Provider/Drush failures, path mismatch, unsupported/incomplete profiles, or Git changes caused during delegated inspection fail nonzero.
 
-No configuration export is performed. Config Ignore's matching rules are not reimplemented, and an `overlay-delta` profile fails closed until its separate #71 strategy contract exists.
+For `overlay-delta`, readiness recognizes the configured path as a protected partial override set. It validates that the directory exists and stays physically inside the Git project root, reports the current Git working tree, and performs no provider or Drush command while a reliable owning validation mechanism is unavailable. Missing YAML, directory size, and file count do not imply drift. The command reports `Owning validation: unavailable` / `Readiness: unavailable` and exits nonzero rather than claiming success.
 
-See [`docs/readiness.md`](docs/readiness.md) for the complete full-export, Config Ignore, Git-integrity, and exit-status contract.
+No configuration export is performed for either strategy. Config Ignore's matching rules are not reimplemented, and full-export semantics are never applied to an overlay/delta directory.
+
+See [`docs/readiness.md`](docs/readiness.md) for the complete strategy, Config Ignore, path-containment, Git-integrity, and exit-status contract.
 
 ### Data pulls
 
@@ -261,7 +265,7 @@ Pantheon Tag routing remains the identity anchor for profile configuration. An e
 - `config-strategy=overlay-delta` for a protected site-specific delta/override set; and
 - a validated relative `config-path` appropriate to that project.
 
-Profile settings remain declarative. They do not themselves run Drupal, export config, start providers, pull data, or mutate Pantheon. Commands that consume them apply separate safety contracts. `pantheon-local readiness` currently consumes complete `full-export` profiles only.
+Profile settings remain declarative. They do not themselves run Drupal, export config, start providers, pull data, or mutate Pantheon. Commands that consume them apply separate safety contracts. `pantheon-local readiness` consumes both strategy labels: full-export can complete provider/Drush inspection, while overlay-delta currently reports its protected boundary and fails closed when owning validation is unavailable.
 
 Examples:
 
@@ -307,8 +311,11 @@ Pantheon Local Tools is intentionally conservative around developer machines and
 - setup runs Composer inside the selected provider and stops immediately when provider start, Composer, database pull, `updb`, or cache rebuild fails;
 - setup does not pull files/Git code, export config, push to Pantheon, or change the meaning of `multidev --start`;
 - `pantheon-local readiness` does not start/rebuild providers or export config and refuses mismatched/unsupported profile semantics;
-- readiness reports Config Ignore conservatively without hiding drift or duplicating Config Ignore matching rules;
-- readiness verifies Git state did not change as a side effect of inspection;
+- full-export readiness reports Config Ignore conservatively without hiding drift or duplicating Config Ignore matching rules;
+- readiness rejects configured directories that escape the Git project root through filesystem links;
+- readiness verifies delegated full-export inspection does not change Git state;
+- overlay-delta readiness never interprets missing YAML, directory size, or file count as drift;
+- overlay-delta readiness does not invoke providers/Drush while owning validation is unavailable and exits nonzero rather than claiming readiness;
 - provider/project configuration remains provider-owned;
 - provider detection and Pantheon Tag routing fail on ambiguity rather than guessing;
 - unsupported Tag profile strategies and unsafe project-relative config paths fail instead of being guessed;
@@ -358,7 +365,7 @@ CI runs syntax validation, ShellCheck, and the shell integration suite on Ubuntu
 - [`docs/configuration.md`](docs/configuration.md) — Git-compatible user configuration and Pantheon Tag profile strategies
 - [`docs/multidev.md`](docs/multidev.md) — Multidev checkout behavior and safety
 - [`docs/setup.md`](docs/setup.md) — provider-aware Drupal checkout bootstrap, failure/retry behavior, and local mutation boundaries
-- [`docs/readiness.md`](docs/readiness.md) — full-export Drupal config inspection, Config Ignore reporting, Git-integrity, and exit semantics
+- [`docs/readiness.md`](docs/readiness.md) — strategy-aware Drupal config readiness, overlay fail-closed reporting, Config Ignore, path containment, Git-integrity, and exit semantics
 - [`docs/pull.md`](docs/pull.md) — database/files pull behavior and Git protection
 - [`docs/status.md`](docs/status.md) — read-only checkout inspection contract
 - [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) — DDEV/Lando boundary and provider architecture

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -66,9 +66,10 @@ Commands:
       database pull, drush updb, then drush cr. --dry-run prints the plan only.
 
   pantheon-local readiness [--provider ddev|lando]
-      Inspect the matched tag profile's Drupal configuration readiness without
-      exporting config or starting the provider. full-export is supported now;
-      unsupported strategies fail safely instead of being reinterpreted.
+      Inspect the matched tag profile's Drupal configuration boundary without
+      exporting config or starting the provider. full-export can complete a
+      readiness inspection; overlay-delta reports its protected partial path
+      and Git state but fails closed while owning validation is unavailable.
 
   pantheon-local pull ENV [--database-only|--files-only] [--provider ddev|lando]
       Refresh local Pantheon database/files without changing checked-out Git

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -104,7 +104,7 @@ When stored configuration uses `provider=auto`, provider selection is based on p
 
 `pantheon-local setup` uses provider-owned command surfaces for provider start, Composer, and Drush. Composer is never silently replaced with host Composer when a supported provider owns the checkout runtime. The database refresh remains delegated through the existing provider-specific `pantheon-local pull --database-only` path.
 
-`pantheon-local readiness` also uses provider-owned Drush. Unlike setup, readiness does not start or rebuild the provider; a runtime that cannot execute the required read-oriented Drush commands is an inspection failure rather than an implicit start request.
+`pantheon-local readiness` uses provider-owned Drush only for strategy states whose readiness contract calls for it. Full-export readiness does not start or rebuild the provider; a runtime that cannot execute its required read-oriented Drush commands is an inspection failure rather than an implicit start request. Overlay-delta readiness does not invoke provider-owned commands while owning validation is unavailable.
 
 A provider-specific implementation detail may change in a patch release when the user-visible command contract and safety properties remain the same.
 
@@ -132,25 +132,42 @@ Setup is a local mutation workflow. It may start/build provider runtime services
 
 `pantheon-local readiness` is a separate read-oriented inspection boundary. It requires a PLT-managed checkout with a recorded `pantheon.tag` that resolves through the existing Git-compatible profile configuration.
 
-For the current `full-export` implementation, both profile values are required:
+Both supported strategy labels require a valid project-relative `config-path`. Readiness requires the configured directory to exist and rejects a lexically valid relative path if the physical directory resolves outside the Git project root through a symlink or another filesystem link.
 
-- `config-strategy=full-export`;
-- a valid project-relative `config-path`.
+### Full-export
 
-The configured path must exist and must correspond to the Drupal runtime `config-sync` path reported by provider-owned `drush core:status --field=config-sync`. PLT must not silently substitute or assume `config/sync`.
+For `config-strategy=full-export`, the configured path must correspond to the Drupal runtime `config-sync` path reported by provider-owned `drush core:status --field=config-sync`. PLT must not silently substitute or assume `config/sync`.
 
-After the path check, readiness uses provider-owned `drush config:status --format=list` to distinguish synchronized configuration from reported active-versus-sync differences. It also attempts enabled-module inspection through Drush to report Config Ignore as `enabled`, `disabled`, or `unavailable`.
+After the path check, full-export readiness uses provider-owned `drush config:status --format=list` to distinguish synchronized configuration from reported active-versus-sync differences. It also attempts enabled-module inspection through Drush to report Config Ignore as `enabled`, `disabled`, or `unavailable`.
 
 Config Ignore detection is advisory. PLT does not duplicate Config Ignore matching semantics, hide reported configuration differences because Config Ignore is enabled, or treat an unavailable module-state query as permission to guess.
 
-Readiness distinguishes an inspection result from an inspection failure:
+Full-export readiness distinguishes an inspection result from an inspection failure:
 
 - synchronized configuration, reported differences, Config Ignore enabled/disabled/unavailable, and a pre-existing modified Git working tree are successful report states and exit `0` when the inspection itself completed reliably;
-- incomplete/unsupported profile data, provider/required-Drush failure, runtime path mismatch, or Git-visible changes caused during inspection fail nonzero.
+- incomplete/unsupported profile data, unsafe/missing configured paths, provider/required-Drush failure, runtime path mismatch, or Git-visible changes caused during inspection fail nonzero.
+
+### Overlay-delta
+
+For `config-strategy=overlay-delta`, the configured path represents a protected partial override set, not a complete Drupal synchronization directory.
+
+Current readiness support validates and reports only facts PLT can establish generically without inventing owning-project semantics:
+
+- the recorded Tag/profile resolves;
+- the configured path is valid, exists, and stays physically inside the checkout;
+- the path is labeled as a protected partial override set;
+- the Git working-tree state is reported and preserved;
+- configuration export is not performed.
+
+While a reliable non-destructive owning validation mechanism is unavailable, overlay readiness must not infer drift from missing YAML, directory size, or file count; must not interpret the directory using full-export `config:status` semantics; and must not invoke DDEV, Lando, or Drush merely to manufacture a readiness result.
+
+The human-readable report includes `Owning validation: unavailable` and `Readiness: unavailable`, then exits nonzero. This is a fail-closed unsupported-readiness state, not evidence that the delta is incorrect.
+
+A later compatible implementation may add a reliable generic or explicitly configured non-destructive owning-validation mechanism while preserving the partial-overlay interpretation and no-export boundary.
+
+### Shared readiness safety
 
 Readiness records no successful-state metadata and performs no configuration export. It must not run `drush config:export`, `drush cex`, or an equivalent write merely because differences are reported.
-
-`overlay-delta` is intentionally unsupported by this initial readiness implementation. Until its separate contract is implemented, the command must fail rather than apply full-export interpretation to a protected partial/delta directory.
 
 ## Safety contract
 
@@ -169,15 +186,19 @@ A compatible `0.1.x` release must preserve these properties:
 - validate all guided `config init` selections before writing so an invalid later value cannot leave a partial configuration update;
 - reject unsupported Tag `config-strategy` values instead of guessing future semantics;
 - reject unsafe/escaping Tag `config-path` values rather than treating them as project-relative paths;
+- reject readiness config directories that escape the Git project root through filesystem links;
 - never make setting a Tag profile property implicitly create a Pantheon Tag route;
 - never interpret `overlay-delta` as permission to flatten or fully export Drupal configuration into the configured delta path;
+- never infer overlay drift from missing YAML, directory size, or file count;
+- never invoke provider/Drush commands for overlay readiness while the owning validation mechanism is unavailable;
+- never report overlay readiness success while owning validation is unavailable;
 - never let `pantheon-local setup` infer its Pantheon database source from Git branch naming or an implicit Live default;
 - never run setup `updb`/`cr` after an earlier required step fails;
 - never make `multidev --start` silently perform the full Drupal setup pipeline;
 - never let `pantheon-local readiness` start/rebuild a provider or automatically export Drupal configuration;
 - never let full-export readiness silently substitute a different config path for the configured Tag profile;
 - never apply full-export readiness semantics to an `overlay-delta` profile; and
-- never report readiness success if the inspection itself changed Git `HEAD` or Git-visible working-tree state.
+- never report readiness success if a delegated full-export inspection changed Git `HEAD` or Git-visible working-tree state.
 
 Safety tightening that converts a previously ambiguous/unsafe case into an explicit failure is considered compatible when documented in release notes.
 
@@ -191,7 +212,7 @@ In particular, the legacy `data.source` migration to independent database/files 
 
 Setup may add local troubleshooting keys for bootstrap status, failed/current step, recorded environment/provider, and update timestamp. `pantheon-local status` may display those fields. Their presence does not make checkout-local state a stable machine API or application configuration.
 
-Readiness consumes the recorded Pantheon Tag and provider identity when available but does not add a persistent readiness-result cache. The current Drupal/Git state is inspected fresh on each run.
+Readiness consumes the recorded Pantheon Tag and provider identity when applicable but does not add a persistent readiness-result cache. The current Drupal/Git state is inspected fresh on each run.
 
 ## Human-readable output
 
@@ -199,7 +220,7 @@ Normal command output is designed for developers and may gain additional labeled
 
 The text output is **not** yet a stable machine-readable API. Scripts that require a formal structured output format should wait for an explicitly documented JSON/porcelain interface rather than parsing incidental spacing.
 
-Exact non-zero numeric exit codes are not part of the `0.1.x` contract; success is exit `0`, failure is nonzero. A successful readiness inspection may still report a review-required state, as described above.
+Exact non-zero numeric exit codes are not part of the `0.1.x` contract; success is exit `0`, failure is nonzero. A successful full-export readiness inspection may still report a review-required state, while overlay-delta currently exits nonzero when owning validation is unavailable.
 
 ## Packaging contract
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ Tag routing remains backward compatible. A route can exist with no configuration
 
 ## Optional Tag profile properties
 
-Issue #68 extends the same `[tag "..."]` subsection with two optional properties consumed by later setup/config-readiness work:
+Issue #68 extends the same `[tag "..."]` subsection with two optional properties consumed by setup/config-readiness work:
 
 - `config-strategy` — one of `full-export` or `overlay-delta`;
 - `config-path` — a relative project path such as `config/sync` or `config/site-overrides`.
@@ -115,13 +115,7 @@ Generic example:
 
 The path is configurable. `config/sync` is a common example, not a product assumption.
 
-Issue #70 adds the read-oriented consumer:
-
-```bash
-pantheon-local readiness
-```
-
-For a PLT-managed checkout whose recorded Pantheon Tag resolves to a `full-export` profile, readiness requires both `config-strategy` and `config-path`, verifies that the configured directory exists, and checks that Drupal's runtime `config-sync` path corresponds to the configured profile path before interpreting `drush config:status` output.
+For a PLT-managed checkout whose recorded Pantheon Tag resolves to a `full-export` profile, `pantheon-local readiness` requires both `config-strategy` and `config-path`, verifies that the configured directory exists and stays physically inside the project root, and checks that Drupal's runtime `config-sync` path corresponds to the configured profile path before interpreting `drush config:status` output.
 
 Readiness reports synchronized/different configuration, Config Ignore module state when detectable, and the final Git working-tree state. It never performs `drush config:export` / `cex`. See [`readiness.md`](readiness.md) for the complete inspection and exit-status contract.
 
@@ -138,9 +132,21 @@ Generic example:
     config-path = config/site-overrides
 ```
 
-A delta directory may contain any small subset of configuration files. Missing YAML, directory size, or file count does not imply drift. Pantheon Local Tools must not treat this profile as permission to run a blanket `drush cex` into the delta path.
+A delta directory may contain any subset of configuration files. Missing YAML, directory size, or file count does not imply drift. Pantheon Local Tools must not treat this profile as permission to run a blanket `drush cex` into the delta path.
 
-The current `pantheon-local readiness` command fails explicitly for `overlay-delta` instead of applying `full-export` rules. Issue #71 owns the strategy-aware readiness behavior after the relevant platform/update mechanism is established.
+`pantheon-local readiness` recognizes this strategy and validates only the generic boundary that PLT can establish safely:
+
+- the Tag/profile resolves through the existing Git-compatible configuration model;
+- the configured path passes the existing project-relative validation rules;
+- the configured directory exists;
+- its physical filesystem location remains inside the Git project root;
+- the current Git working-tree state is reported and preserved.
+
+While no reliable generic non-destructive owning validation mechanism is established, readiness does **not** invoke DDEV, Lando, or Drush for `overlay-delta`. It reports the path as a protected partial override set, reports `Owning validation: unavailable`, performs no export, and exits nonzero rather than claiming the project is ready.
+
+That nonzero result is a safety state, not evidence that the delta is wrong. PLT intentionally does not classify empty, tiny, or large delta sets as drift and does not compare missing files against complete active Drupal configuration.
+
+A future owning-validation implementation must preserve this boundary and may only replace the unavailable state when it has an explicit reliable non-destructive mechanism for the relevant merge/import/update semantics.
 
 ## Validation and failure behavior
 
@@ -162,9 +168,11 @@ overlay-delta
 - contain no empty path segment (`//`);
 - contain no `.` or `..` path segment.
 
+Readiness adds a filesystem-boundary check: even a lexically valid relative path is rejected if the configured directory resolves outside the Git project root through a symlink or another filesystem link.
+
 A profile setter refuses a Pantheon Tag that has no existing `directory` route. This keeps routing identity explicit and prevents configuration-only subsections from silently changing Multidev Tag matching.
 
-The two properties are independently optional so users can build or edit a profile incrementally. A command that requires a complete strategy/path pair validates that requirement itself and fails closed when the profile is incomplete. `pantheon-local readiness` is such a consumer for `full-export`.
+The two properties are independently optional so users can build or edit a profile incrementally. A command that requires a complete strategy/path pair validates that requirement itself and fails closed when the profile is incomplete. `pantheon-local readiness` is such a consumer for both supported strategy labels.
 
 ## Organization-specific values
 
@@ -184,4 +192,4 @@ The profile is declarative routing/setup metadata. It does not grant permission 
 - export Drupal configuration;
 - commit or push project changes.
 
-A consumer such as `pantheon-local readiness` may run explicitly documented provider-owned, read-oriented Drush inspection commands. That consumer remains responsible for its own runtime, mutation, failure, and Git-integrity boundaries.
+A consumer such as `pantheon-local readiness` may run explicitly documented provider-owned, read-oriented Drush inspection commands only when its strategy contract calls for them. Current `overlay-delta` readiness does not invoke provider-owned commands while owning validation semantics remain unavailable. Each consumer remains responsible for its own runtime, mutation, failure, and Git-integrity boundaries.

--- a/docs/readiness.md
+++ b/docs/readiness.md
@@ -2,7 +2,7 @@
 
 `pantheon-local readiness` inspects whether a Pantheon Local Tools-managed Drupal checkout is ready for configuration review without exporting configuration or starting/rebuilding its local provider.
 
-The command is intentionally strategy-aware. Issue #70 implements the `full-export` strategy only; `overlay-delta` remains a separate safety problem owned by #71 and fails closed rather than inheriting full-export behavior.
+The command is intentionally strategy-aware. `full-export` can complete a provider/Drush-backed readiness inspection. `overlay-delta` is treated as a protected partial override set and is inspected only far enough to validate the configured boundary and Git state; it fails closed while a reliable owning validation mechanism is unavailable.
 
 ## Command
 
@@ -17,13 +17,15 @@ pantheon-local readiness
 pantheon-local readiness --provider ddev
 ```
 
-The provider must already be usable. Readiness invokes provider-owned Drush but does not start or rebuild DDEV/Lando.
+The provider must already be usable for `full-export`. Readiness never starts or rebuilds DDEV/Lando.
+
+For `overlay-delta`, provider selection is not evaluated while owning validation is unavailable. A syntactically valid `--provider` value may be supplied, but no provider or Drush command is invoked.
 
 ## Profile authority
 
 Readiness requires a PLT-managed checkout with a recorded `pantheon.tag`. That Tag resolves the existing Git-compatible profile created through `pantheon-local config tag profile`.
 
-For `full-export`, both properties are required:
+A `full-export` example:
 
 ```ini
 [tag "Full Export Example"]
@@ -32,9 +34,20 @@ For `full-export`, both properties are required:
     config-path = config/project-export
 ```
 
-The path is user/project configuration. `config/sync` is a common example, not a PLT default or hard-coded assumption.
+An `overlay-delta` example:
 
-If the recorded Tag has no complete profile, the configured directory does not exist, the strategy is unsupported, or the provider cannot be resolved safely, readiness fails before claiming a result.
+```ini
+[tag "Protected Overlay Example"]
+    directory = protected-overlay-example
+    config-strategy = overlay-delta
+    config-path = config/site-overrides
+```
+
+The path is user/project configuration. `config/sync` and `config/site-overrides` are examples, not PLT defaults or hard-coded assumptions.
+
+Profile values are validated by the existing Tag-profile configuration seam. Readiness additionally requires the configured directory to exist and verifies that its physical filesystem location remains inside the Git project root. A project-relative path that resolves outside the checkout through a symlink or another filesystem link fails before provider/Drush behavior is considered.
+
+If the recorded Tag has no complete profile, the configured directory does not exist, the path escapes the project root, or the strategy is unsupported, readiness fails before claiming a result.
 
 ## Full-export inspection
 
@@ -42,7 +55,8 @@ A successful full-export inspection performs these read-oriented steps:
 
 ```text
 resolve recorded Tag/profile
-→ verify configured config-path exists
+→ verify configured config-path exists and stays inside the project root
+→ resolve the selected provider
 → provider-owned drush core:status --field=config-sync
 → verify Drupal's runtime config-sync path matches the configured profile path
 → provider-owned drush config:status --format=list
@@ -55,11 +69,54 @@ The runtime path check prevents a stale or incorrect profile from being treated 
 
 Drush `config:status` reports active-versus-sync configuration differences. PLT treats non-empty list output as `differences detected` and empty list output as `synchronized`; it does not convert differences into an automatic export action.
 
+## Overlay/delta inspection
+
+An `overlay-delta` profile identifies a protected partial override set. The configured directory is **not** interpreted as Drupal's complete synchronization directory.
+
+Current overlay inspection is deliberately bounded:
+
+```text
+resolve recorded Tag/profile
+→ verify configured config-path exists and stays inside the project root
+→ snapshot/report Git working-tree state
+→ report the delta interpretation as a protected partial override set
+→ report owning validation as unavailable
+→ perform no provider/Drush/config-export action
+→ exit nonzero
+```
+
+The command does not inspect the directory's contents to infer readiness. In particular:
+
+- missing YAML does not imply drift;
+- an empty directory does not imply drift;
+- one file does not imply a valid or invalid delta;
+- a large file count does not imply a full export;
+- directory size has no readiness meaning;
+- file names are not compared against active Drupal config as if the directory were complete.
+
+Because the generic product does not yet have a reliable non-destructive command or comparison that represents every owning project's merge/import/update semantics, the report uses:
+
+```text
+Provider:              not invoked
+Delta interpretation:  protected partial override set
+Drupal configuration:  not interpreted as full export
+Owning validation:     unavailable
+Config Ignore:         not inspected
+Config export:         not performed
+Readiness:             unavailable
+```
+
+and exits nonzero.
+
+That nonzero result is intentional. It means PLT successfully identified and protected the overlay boundary but **cannot yet make a readiness claim**. It must not convert missing knowledge into a green status.
+
+A later implementation may replace `Owning validation: unavailable` only after a reliable generic or explicitly configured non-destructive validation mechanism is designed and tested. That later mechanism must preserve the same rule that the protected delta directory is not a complete export.
+
 ## Config Ignore
 
-Config Ignore is an optional Drupal module/site characteristic, not a PLT profile strategy.
+Config Ignore is an optional Drupal module/site characteristic used only by the current `full-export` readiness inspection. It is not a PLT profile strategy and is not inspected for `overlay-delta` while owning validation is unavailable.
 
-Readiness asks Drupal for enabled module names through provider-owned Drush:
+For `full-export`, readiness asks Drupal for enabled module names through provider-owned Drush:
 
 ```text
 drush pm:list --type=module --status=enabled --field=name
@@ -71,7 +128,7 @@ The report uses three states:
 - `disabled` — module inspection succeeds and `config_ignore` is not enabled;
 - `unavailable` — module-state inspection could not be completed reliably.
 
-`unavailable` is advisory rather than fatal after the core configuration inspection has succeeded. PLT does not guess the missing state.
+`unavailable` is advisory rather than fatal after the core full-export configuration inspection has succeeded. PLT does not guess the missing state.
 
 PLT deliberately does **not** reimplement Config Ignore's matching, import/export, or runtime semantics. When differences are present and Config Ignore is enabled—or its state is unavailable—the developer must review the Drupal/site-specific behavior before choosing any later export action.
 
@@ -84,15 +141,17 @@ Upstream references:
 
 ## Git integrity
 
-Readiness snapshots both Git `HEAD` and the Git-visible working tree before running Drush inspection commands and checks them again afterward.
+Full-export readiness snapshots both Git `HEAD` and the Git-visible working tree before running Drush inspection commands and checks them again afterward.
 
-A checkout may already be modified before inspection. That is a reportable review state and does not make the inspection itself fail.
+Overlay readiness does not run external provider/Drush inspection commands. It still reads `HEAD` and the working tree before reporting so a pre-existing dirty tree is visible and preserved.
 
-However, if the inspection changes `HEAD` or changes the working tree relative to the pre-inspection snapshot, readiness fails instead of reporting success. A read-oriented inspection command is not allowed to silently become a source mutation path.
+A checkout may already be modified before inspection. That is a reportable state and does not authorize cleanup or reset.
+
+For full-export, if the delegated inspection changes `HEAD` or changes the working tree relative to the pre-inspection snapshot, readiness fails instead of reporting success. A read-oriented inspection command is not allowed to silently become a source mutation path.
 
 ## Output and exit semantics
 
-Synchronized configuration and a clean working tree produce a result such as:
+Synchronized full-export configuration and a clean working tree produce a result such as:
 
 ```text
 Drupal configuration:  synchronized
@@ -102,7 +161,7 @@ Git working tree:      clean
 Readiness:             ready
 ```
 
-Configuration differences are reported conservatively:
+Full-export configuration differences are reported conservatively:
 
 ```text
 Drupal configuration:  differences detected
@@ -112,17 +171,13 @@ Git working tree:      clean
 Readiness:             review configuration differences
 ```
 
-A pre-existing modified working tree is also surfaced:
+A pre-existing modified working tree is also surfaced for either strategy.
 
-```text
-Git working tree:      modified
-Readiness:             review working tree
-```
+Exit semantics distinguish **inspection results** from **unsupported readiness claims** and **inspection failures**:
 
-Exit semantics distinguish **inspection results** from **inspection failures**:
-
-- exit `0` when inspection completed reliably, including synchronized config, detected differences, Config Ignore enabled/disabled/unavailable, or a pre-existing modified working tree;
-- nonzero when PLT cannot inspect safely or completely, including incomplete/unsupported profile data, provider/Drush failure, runtime config-path mismatch, or Git-visible mutation caused during inspection.
+- exit `0` for a completed `full-export` inspection, including synchronized config, detected differences, Config Ignore enabled/disabled/unavailable, or a pre-existing modified Git working tree;
+- exit nonzero for `overlay-delta` while the owning validation mechanism is unavailable, even though the command prints the known boundary/Git state;
+- exit nonzero when PLT cannot inspect safely or completely, including incomplete/unsupported profile data, missing/escaping configured paths, provider/Drush failure, runtime config-path mismatch, or Git-visible mutation caused during full-export inspection.
 
 The human-readable output is not a stable porcelain/JSON API.
 
@@ -135,12 +190,8 @@ drush config:export
 drush cex
 ```
 
-It does not write YAML, recommend a blind export merely because differences exist, or claim that a difference is erroneous simply because Config Ignore is enabled.
+For `overlay-delta`, it also never runs `drush config:status` while the directory's owning validation semantics are unknown.
+
+Readiness does not write YAML, recommend a blind export merely because differences exist, or treat an overlay directory as incomplete because files are absent.
 
 Any future export capability is a separate explicit mutation boundary owned by #72.
-
-## Overlay/delta boundary
-
-An `overlay-delta` profile identifies a protected partial/delta configuration workflow, not a complete sync directory. Issue #70 does not attempt to validate such a directory using full-export rules.
-
-Until #71 establishes the owning platform/update mechanism and its safe inspection contract, `pantheon-local readiness` fails explicitly for `overlay-delta`.

--- a/libexec/pantheon-local-readiness
+++ b/libexec/pantheon-local-readiness
@@ -14,27 +14,41 @@ Inspect Drupal configuration readiness for the current Pantheon Local Tools-
 managed checkout without exporting configuration or starting the provider.
 
 Current strategy support:
-  full-export    Inspect the matched tag profile's configured config-path.
-  overlay-delta  Not yet supported by readiness; the command fails safely.
+  full-export    Inspect the matched tag profile's complete config export.
+  overlay-delta  Inspect the protected delta boundary without interpreting it
+                 as a complete export. Owning validation remains fail-closed
+                 until a reliable project/update mechanism is established.
 
 Inspection steps for full-export:
   1. Resolve the recorded Pantheon Tag and its config-strategy/config-path.
-  2. Verify the configured path exists and matches Drupal's runtime config-sync
-     path reported by provider-owned Drush.
+  2. Verify the configured path exists, stays within the project root, and
+     matches Drupal's runtime config-sync path reported by provider-owned Drush.
   3. Run provider-owned drush config:status --format=list.
   4. Detect whether the Config Ignore module is enabled when Drush can report it.
   5. Report the final Git working-tree state and readiness summary.
 
+Inspection steps for overlay-delta:
+  1. Resolve the recorded Pantheon Tag and its config-strategy/config-path.
+  2. Verify the configured path exists and stays within the project root.
+  3. Treat the path only as a protected partial override set. Missing YAML,
+     directory size, and file count are not interpreted as drift.
+  4. Report Git working-tree state and owning validation as unavailable.
+  5. Exit nonzero until a reliable non-destructive owning validation mechanism
+     is established. No provider-owned Drush command is invoked for this state.
+
 Safety and exit semantics:
   * No drush config:export / cex is run. Configuration files are not written.
-  * The provider is not started or rebuilt. If provider-owned Drush cannot run,
-    readiness fails instead of starting the environment implicitly.
-  * Drupal configuration differences and an already-modified Git working tree
-    are reportable review states and still exit 0 when inspection succeeds.
-  * Missing/unsupported profile data, provider/Drush failures, runtime path
-    mismatch, or Git changes caused during inspection exit nonzero.
-  * Config Ignore detection is advisory. If module-state inspection is
-    unavailable, readiness reports "unavailable" rather than guessing.
+  * The provider is not started or rebuilt.
+  * Full-export configuration differences and an already-modified Git working
+    tree are reportable review states and still exit 0 when inspection succeeds.
+  * Overlay-delta with unknown owning validation reports what is known but exits
+    nonzero rather than claiming readiness or applying full-export semantics.
+  * Missing/unsupported profile data, unsafe/missing configured paths,
+    provider/Drush failures, runtime path mismatch, or Git changes caused during
+    full-export inspection exit nonzero.
+  * Config Ignore detection is advisory for full-export. If module-state
+    inspection is unavailable, readiness reports "unavailable" rather than
+    guessing.
 
 Examples:
   pantheon-local readiness
@@ -96,10 +110,6 @@ resolve_provider() {
   local root=$1 state=$2 override=$3 recorded=''
 
   if [ -n "$override" ]; then
-    case "$override" in
-      ddev|lando) ;;
-      *) die '--provider must be ddev or lando' ;;
-    esac
     provider_config_present "$root" "$override" || \
       die "$override provider selected but its project configuration is missing"
     printf '%s\n' "$override"
@@ -126,6 +136,20 @@ profile_get() {
   local tag=$1 property=$2
   [ -x "$PROFILE" ] || die "tag-profile module is missing or not executable: $PROFILE"
   "$PROFILE" get "$tag" "$property"
+}
+
+require_config_directory() {
+  local root=$1 config_path=$2 strategy=$3 root_physical config_physical
+
+  [ -d "$root/$config_path" ] || \
+    die "configured $strategy config-path does not exist as a directory: $config_path"
+
+  root_physical=$(cd "$root" && pwd -P)
+  config_physical=$(cd "$root/$config_path" && pwd -P)
+  case "$config_physical" in
+    "$root_physical"/*) ;;
+    *) die "configured $strategy config-path escapes the project root through filesystem links: $config_path" ;;
+  esac
 }
 
 run_drush_capture() {
@@ -170,6 +194,46 @@ detect_config_ignore() {
   fi
 }
 
+report_overlay_delta() {
+  local root=$1 tag=$2 strategy=$3 config_path=$4
+  local head_before head_after git_before git_after git_state
+
+  head_before=$(git -C "$root" rev-parse HEAD)
+  git_before=$(git -C "$root" status --porcelain --untracked-files=normal)
+  head_after=$(git -C "$root" rev-parse HEAD)
+  git_after=$(git -C "$root" status --porcelain --untracked-files=normal)
+
+  [ "$head_after" = "$head_before" ] || \
+    die 'overlay-delta readiness inspection changed Git HEAD; refusing to report readiness'
+  [ "$git_after" = "$git_before" ] || \
+    die 'overlay-delta readiness inspection changed the Git working tree; refusing to report readiness'
+
+  if [ -n "$git_after" ]; then
+    git_state=modified
+  else
+    git_state=clean
+  fi
+
+  printf 'Pantheon Local Tools readiness\n\n'
+  printf 'Directory:             %s\n' "$root"
+  printf 'Pantheon Tag:          %s\n' "$tag"
+  printf 'Config strategy:       %s\n' "$strategy"
+  printf 'Configured config path:%s%s\n' ' ' "$config_path"
+  printf 'Provider:              not invoked\n'
+  printf 'Delta interpretation:  protected partial override set\n'
+  printf 'Drupal configuration:  not interpreted as full export\n'
+  printf 'Owning validation:     unavailable\n'
+  printf 'Config Ignore:         not inspected\n'
+  printf 'Config export:         not performed\n'
+  printf 'Git working tree:      %s\n' "$git_state"
+  printf 'Readiness:             unavailable\n'
+  printf '\nMissing YAML, directory size, and file count are not interpreted as overlay drift.\n'
+  printf 'No provider or Drush command was invoked.\n'
+  printf 'A reliable non-destructive owning validation mechanism has not been established, so readiness fails closed.\n'
+
+  return 1
+}
+
 readiness_command() {
   local provider_override='' root git_dir state tag strategy config_path provider
   local runtime_config_path config_output config_entries config_state config_ignore
@@ -180,6 +244,10 @@ readiness_command() {
       --provider)
         [ "$#" -ge 2 ] || die '--provider requires ddev or lando'
         provider_override=$2
+        case "$provider_override" in
+          ddev|lando) ;;
+          *) die '--provider must be ddev or lando' ;;
+        esac
         shift 2
         ;;
       -h|--help|help)
@@ -206,13 +274,16 @@ readiness_command() {
   strategy=$(profile_get "$tag" config-strategy)
   config_path=$(profile_get "$tag" config-path)
   case "$strategy" in
-    full-export) ;;
-    overlay-delta) die 'overlay-delta readiness is not implemented yet; refusing to apply full-export semantics' ;;
+    full-export|overlay-delta) ;;
     *) die "unsupported config strategy for readiness: $strategy" ;;
   esac
 
-  [ -d "$root/$config_path" ] || \
-    die "configured full-export config-path does not exist as a directory: $config_path"
+  require_config_directory "$root" "$config_path" "$strategy"
+
+  if [ "$strategy" = overlay-delta ]; then
+    report_overlay_delta "$root" "$tag" "$strategy" "$config_path" || return 1
+    return
+  fi
 
   provider=$(resolve_provider "$root" "$state" "$provider_override")
   require_command "$provider"

--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -45,6 +45,8 @@ for expected in \
 do
   assert_contains "$help_output" "$expected"
 done
+assert_contains "$help_output" 'overlay-delta reports its protected partial path'
+assert_contains "$help_output" 'fails closed while owning validation is unavailable'
 
 config_help=$(bash "$CLI" config help)
 assert_contains "$config_help" 'pantheon-local config init [--root PATH] [--provider auto|ddev|lando]'
@@ -78,10 +80,13 @@ readiness_help=$(bash "$CLI" readiness --help)
 assert_contains "$readiness_help" 'pantheon-local readiness [--provider ddev|lando]'
 assert_contains "$readiness_help" 'full-export'
 assert_contains "$readiness_help" 'overlay-delta'
-assert_contains "$readiness_help" 'configured config-path'
+assert_contains "$readiness_help" 'protected partial override set'
+assert_contains "$readiness_help" 'Missing YAML'
+assert_contains "$readiness_help" 'No provider-owned Drush command is invoked'
 assert_contains "$readiness_help" 'No drush config:export / cex is run.'
 assert_contains "$readiness_help" 'still exit 0 when inspection succeeds'
-assert_contains "$readiness_help" 'Config Ignore detection is advisory.'
+assert_contains "$readiness_help" 'Owning validation remains fail-closed'
+assert_contains "$readiness_help" 'Config Ignore detection is advisory for full-export.'
 assert_contains "$readiness_help" 'provider is not started or rebuilt'
 
 pull_help=$(bash "$CLI" pull --help)

--- a/tests/test-readiness.sh
+++ b/tests/test-readiness.sh
@@ -11,6 +11,7 @@ mkdir -p "$MOCK_BIN"
 
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
+assert_not_contains() { case "$1" in *"$2"*) fail "expected output not to contain [$2], got [$1]" ;; *) ;; esac; }
 assert_file_contains() { grep -F "$2" "$1" >/dev/null 2>&1 || fail "expected $1 to contain [$2]"; }
 assert_file_not_contains() { if [ -f "$1" ] && grep -F "$2" "$1" >/dev/null 2>&1; then fail "expected $1 not to contain [$2]"; fi; }
 assert_line() {
@@ -108,13 +109,28 @@ create_repo() {
   bash "$CLI" config tag profile set "$tag" config-path "$config_path"
 }
 
+capture_readiness_failure() {
+  local repo=$1
+  shift
+  local output status
+  set +e
+  output=$(cd "$repo" && bash "$CLI" readiness "$@" 2>&1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "expected readiness to fail for $repo"
+  printf '%s\n' "$output"
+}
+
 assert_contains "$(bash "$CLI" --help)" 'pantheon-local readiness [--provider ddev|lando]'
 readiness_help=$(bash "$CLI" readiness --help)
 assert_contains "$readiness_help" 'full-export'
 assert_contains "$readiness_help" 'overlay-delta'
+assert_contains "$readiness_help" 'protected partial override set'
+assert_contains "$readiness_help" 'No provider-owned Drush command is invoked'
 assert_contains "$readiness_help" 'No drush config:export / cex is run.'
 assert_contains "$readiness_help" 'still exit 0 when inspection succeeds'
-assert_contains "$readiness_help" 'Config Ignore detection is advisory.'
+assert_contains "$readiness_help" 'Owning validation remains fail-closed'
+assert_contains "$readiness_help" 'Config Ignore detection is advisory for full-export.'
 
 # Synchronized full-export config with a nonstandard configured path is ready.
 SYNCED="$TMP_ROOT/synced"
@@ -188,16 +204,102 @@ assert_line "$MOCK_LOG" 1 'ddev|drush|core:status|--field=config-sync'
 assert_line "$MOCK_LOG" 2 'ddev|drush|config:status|--format=list'
 assert_line "$MOCK_LOG" 3 'ddev|drush|pm:list|--type=module|--status=enabled|--field=name'
 
-# Overlay profiles fail closed before invoking provider commands.
+# Overlay profiles report the protected boundary but fail closed without provider/Drush calls.
 OVERLAY="$TMP_ROOT/overlay"
-create_repo "$OVERLAY" lando 'Overlay Example' overlay-delta config/overrides
+create_repo "$OVERLAY" lando 'Shared Platform Example' overlay-delta config/site-overrides
 reset_mocks
-if (cd "$OVERLAY" && bash "$CLI" readiness >/dev/null 2>&1); then
-  fail 'readiness applied full-export behavior to overlay-delta'
-fi
-[ ! -s "$MOCK_LOG" ] || fail 'overlay-delta refusal invoked provider commands'
+overlay_output=$(capture_readiness_failure "$OVERLAY")
+assert_contains "$overlay_output" 'Pantheon Tag:          Shared Platform Example'
+assert_contains "$overlay_output" 'Config strategy:       overlay-delta'
+assert_contains "$overlay_output" 'Configured config path: config/site-overrides'
+assert_contains "$overlay_output" 'Provider:              not invoked'
+assert_contains "$overlay_output" 'Delta interpretation:  protected partial override set'
+assert_contains "$overlay_output" 'Drupal configuration:  not interpreted as full export'
+assert_contains "$overlay_output" 'Owning validation:     unavailable'
+assert_contains "$overlay_output" 'Config Ignore:         not inspected'
+assert_contains "$overlay_output" 'Config export:         not performed'
+assert_contains "$overlay_output" 'Git working tree:      clean'
+assert_contains "$overlay_output" 'Readiness:             unavailable'
+assert_contains "$overlay_output" 'Missing YAML, directory size, and file count are not interpreted as overlay drift.'
+assert_contains "$overlay_output" 'No provider or Drush command was invoked.'
+assert_not_contains "$overlay_output" 'differences detected'
+assert_not_contains "$overlay_output" 'synchronized'
+[ ! -s "$MOCK_LOG" ] || fail 'overlay-delta inspection invoked provider commands'
 
-# Missing configured directory fails before provider-owned Drush.
+# A valid explicit provider flag is syntax only while overlay validation is unavailable.
+reset_mocks
+overlay_provider_output=$(capture_readiness_failure "$OVERLAY" --provider ddev)
+assert_contains "$overlay_provider_output" 'Provider:              not invoked'
+[ ! -s "$MOCK_LOG" ] || fail 'overlay-delta --provider invoked provider commands'
+
+# Invalid provider values still fail at the public CLI boundary.
+reset_mocks
+invalid_provider_output=$(capture_readiness_failure "$OVERLAY" --provider other)
+assert_contains "$invalid_provider_output" '--provider must be ddev or lando'
+[ ! -s "$MOCK_LOG" ] || fail 'invalid provider value invoked provider commands'
+
+# Empty overlay directories do not become missing-drift findings.
+OVERLAY_EMPTY="$TMP_ROOT/overlay-empty"
+create_repo "$OVERLAY_EMPTY" lando 'Empty Overlay Example' overlay-delta config/empty-overrides
+git -C "$OVERLAY_EMPTY" rm -q config/empty-overrides/system.site.yml
+git -C "$OVERLAY_EMPTY" commit -qm 'Make overlay directory empty'
+mkdir -p "$OVERLAY_EMPTY/config/empty-overrides"
+reset_mocks
+empty_output=$(capture_readiness_failure "$OVERLAY_EMPTY")
+assert_contains "$empty_output" 'Delta interpretation:  protected partial override set'
+assert_contains "$empty_output" 'Owning validation:     unavailable'
+assert_not_contains "$empty_output" 'differences detected'
+[ ! -s "$MOCK_LOG" ] || fail 'empty overlay inspection invoked provider commands'
+
+# Large overlay directories have no special readiness meaning either.
+OVERLAY_LARGE="$TMP_ROOT/overlay-large"
+create_repo "$OVERLAY_LARGE" lando 'Large Overlay Example' overlay-delta config/many-overrides
+index=1
+while [ "$index" -le 40 ]; do
+  printf 'id: %s\n' "$index" > "$OVERLAY_LARGE/config/many-overrides/example.$index.yml"
+  index=$((index + 1))
+done
+git -C "$OVERLAY_LARGE" add config/many-overrides
+git -C "$OVERLAY_LARGE" commit -qm 'Add many overlay fixtures'
+reset_mocks
+large_output=$(capture_readiness_failure "$OVERLAY_LARGE")
+assert_contains "$large_output" 'Owning validation:     unavailable'
+assert_contains "$large_output" 'Missing YAML, directory size, and file count are not interpreted as overlay drift.'
+assert_not_contains "$large_output" 'differences detected'
+[ ! -s "$MOCK_LOG" ] || fail 'large overlay inspection invoked provider commands'
+
+# A pre-existing dirty overlay tree is reported and preserved.
+OVERLAY_DIRTY="$TMP_ROOT/overlay-dirty"
+create_repo "$OVERLAY_DIRTY" lando 'Dirty Overlay Example' overlay-delta config/dirty-overrides
+printf 'local overlay notes\n' > "$OVERLAY_DIRTY/local-notes.txt"
+reset_mocks
+overlay_dirty_output=$(capture_readiness_failure "$OVERLAY_DIRTY")
+assert_contains "$overlay_dirty_output" 'Git working tree:      modified'
+assert_contains "$overlay_dirty_output" 'Readiness:             unavailable'
+[ -f "$OVERLAY_DIRTY/local-notes.txt" ] || fail 'overlay readiness removed an existing untracked file'
+[ ! -s "$MOCK_LOG" ] || fail 'dirty overlay inspection invoked provider commands'
+
+# Missing overlay directory fails before provider commands.
+OVERLAY_MISSING="$TMP_ROOT/overlay-missing"
+create_repo "$OVERLAY_MISSING" lando 'Missing Overlay Example' overlay-delta config/missing-overrides
+rm -rf "$OVERLAY_MISSING/config/missing-overrides"
+reset_mocks
+overlay_missing_output=$(capture_readiness_failure "$OVERLAY_MISSING")
+assert_contains "$overlay_missing_output" 'configured overlay-delta config-path does not exist as a directory: config/missing-overrides'
+[ ! -s "$MOCK_LOG" ] || fail 'missing overlay path invoked provider commands'
+
+# A lexically safe path that escapes through a symlink is rejected.
+OVERLAY_SYMLINK="$TMP_ROOT/overlay-symlink"
+create_repo "$OVERLAY_SYMLINK" lando 'Symlink Overlay Example' overlay-delta config/external-overrides
+rm -rf "$OVERLAY_SYMLINK/config/external-overrides"
+mkdir -p "$TMP_ROOT/external-overrides"
+ln -s "$TMP_ROOT/external-overrides" "$OVERLAY_SYMLINK/config/external-overrides"
+reset_mocks
+symlink_output=$(capture_readiness_failure "$OVERLAY_SYMLINK")
+assert_contains "$symlink_output" 'config-path escapes the project root through filesystem links'
+[ ! -s "$MOCK_LOG" ] || fail 'escaping overlay path invoked provider commands'
+
+# Missing configured full-export directory fails before provider-owned Drush.
 MISSING_DIR="$TMP_ROOT/missing-dir"
 create_repo "$MISSING_DIR" lando 'Missing Directory' full-export config/will-disappear
 rm -rf "$MISSING_DIR/config/will-disappear"


### PR DESCRIPTION
## Summary

Implements the bounded #71 readiness slice for generic `overlay-delta` profiles without inventing owning-project semantics.

- validates the configured profile path and rejects filesystem-link escapes outside the Git checkout;
- treats `overlay-delta` as a protected partial override set, never a complete Drupal export;
- reports Git working-tree state while preserving it;
- reports `Owning validation: unavailable` / `Readiness: unavailable` and exits nonzero while no reliable non-destructive owning validation mechanism exists;
- invokes no DDEV/Lando/Drush command for that unavailable overlay state;
- never interprets missing YAML, directory size, or file count as drift;
- preserves existing `full-export` provider/Drush behavior and the no-export boundary.

## Validation

Focused coverage includes:

- arbitrary generic Tag/path values;
- empty, small, large, and dirty overlay sets;
- missing configured directories;
- physical path escape through a symlink;
- explicit/invalid provider option handling;
- assertions that overlay readiness does not invoke provider mocks, `config:status`, `cex`, or `config:export`;
- unchanged full-export synchronized/difference/Config Ignore/provider/mutation tests;
- focused CLI-help assertions.

GitHub Actions runs shell syntax, ShellCheck, and the complete shell integration suite on Ubuntu and macOS.

Closes #71.