### PR TITLE
Add explicit strategy-aware Drupal config export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,17 @@ The project follows Semantic Versioning for its public command/configuration con
 - Added bootstrap status/step/timestamp reporting to checkout-local state and `pantheon-local status`.
 - Added `pantheon-local readiness [--provider ddev|lando]` for read-oriented `full-export` Drupal configuration inspection using the recorded Tag profile, configured config path, provider-owned Drush, Config Ignore module-state reporting, and final Git state.
 - Added fail-closed `overlay-delta` readiness reporting that validates the configured protected partial path and Git state without invoking a provider/Drush or treating file count/missing YAML as drift.
+- Added explicit `pantheon-local config export [--provider ddev|lando] [--yes]` for confirmed `full-export` Drupal configuration mutation with clean-path preflight, Config Ignore runtime awareness, post-export change reporting, and no automatic Git commit/push.
 
 ### Changed
 
 - `pantheon-local config list` now reports configured Tag profile properties in addition to the established root/provider and Tag-directory lines.
 - `pantheon-local config tag unset TAG` now removes that Tag's optional profile properties so stale strategy/path state is not orphaned after route deletion.
-- Debian/Homebrew/release packaging coverage now includes the Tag-profile, Drupal-setup, and readiness command modules.
+- Debian/Homebrew/release packaging coverage now includes the Tag-profile, Drupal-setup, readiness, and explicit config-export command modules.
 - Drupal setup now composes the existing guarded database-only pull after provider-owned Composer install, then runs `drush updb -y` and `drush cr`, stopping on the first failed step.
 - Full-export readiness now verifies the configured profile path against Drupal's runtime config-sync path, reports configuration differences as review states rather than automatically exporting, and fails if inspection itself changes Git-visible source state.
 - Readiness now rejects configured directories that escape the Git project root through filesystem links. Overlay-delta reports `Owning validation: unavailable` / `Readiness: unavailable` and exits nonzero until a reliable non-destructive owning validation mechanism exists.
+- Config export refuses `overlay-delta`, requires the configured full-export path to be Git-clean before mutation, requires a reliable Config Ignore module-state check, and reports partial local changes if provider-owned `drush config:export` fails after writing files.
 
 ## 0.1.1 — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ For `full-export`, readiness uses the configured path, verifies it against Drupa
 
 For `overlay-delta`, readiness validates that the configured protected partial path exists and remains inside the project root, reports Git state, performs no provider/Drush call, and exits nonzero with `Owning validation: unavailable` rather than inventing drift/readiness semantics. Missing YAML, directory size, and file count are not treated as drift. Neither strategy performs `drush cex` / `config:export`. See [`docs/readiness.md`](docs/readiness.md).
 
+When a `full-export` readiness review is complete and you deliberately want to mutate tracked configuration files, use the separate export command:
+
+```bash
+pantheon-local config export
+```
+
+Interactive use confirms before mutation. Automation must supply `--yes`. The configured export path must be Git-clean before export, `overlay-delta` is refused, and PLT never stages, commits, pushes, or modifies a remote Pantheon environment. See [`docs/config-export.md`](docs/config-export.md).
+
 ## Commands
 
 Run `pantheon-local help` or `pantheon-local --help` for the complete in-tool command reference.
@@ -152,6 +160,7 @@ pantheon-local config tag profile get TAG PROPERTY
 pantheon-local config tag profile set TAG PROPERTY VALUE
 pantheon-local config tag profile unset TAG PROPERTY
 pantheon-local config tag profile list [TAG]
+pantheon-local config export [--provider ddev|lando] [--yes]
 
 pantheon-local multidev SITE.ENV
   --provider ddev|lando
@@ -176,7 +185,7 @@ pantheon-local version
 pantheon-local --version
 ```
 
-Focused help remains available for nontrivial commands, for example `pantheon-local config help`, `pantheon-local config tag profile --help`, `pantheon-local multidev --help`, `pantheon-local setup --help`, `pantheon-local readiness --help`, `pantheon-local pull --help`, and `pantheon-local status --help`.
+Focused help remains available for nontrivial commands, for example `pantheon-local config help`, `pantheon-local config tag profile --help`, `pantheon-local config export --help`, `pantheon-local multidev --help`, `pantheon-local setup --help`, `pantheon-local readiness --help`, `pantheon-local pull --help`, and `pantheon-local status --help`.
 
 ## Core workflows
 
@@ -213,6 +222,18 @@ For `overlay-delta`, readiness recognizes the configured path as a protected par
 No configuration export is performed for either strategy. Config Ignore's matching rules are not reimplemented, and full-export semantics are never applied to an overlay/delta directory.
 
 See [`docs/readiness.md`](docs/readiness.md) for the complete strategy, Config Ignore, path-containment, Git-integrity, and exit-status contract.
+
+### Explicit Drupal configuration export
+
+`pantheon-local config export [--provider ddev|lando] [--yes]` is the deliberate tracked-source mutation boundary for `full-export` profiles. It is separate from readiness, status, setup, Multidev start, and Tag matching so a reported configuration difference can never turn itself into an automatic export.
+
+Before mutation, PLT requires the configured export path to be Git-clean, completes the normal full-export readiness inspection, requires Config Ignore module-state inspection to succeed, prints the mutation plan, and confirms interactively unless `--yes` was supplied. Unrelated dirty files elsewhere in the checkout are preserved.
+
+The actual mutation is provider-owned `drush config:export -y`. PLT does not pass Drush staging/commit options and does not stage, commit, push, or perform a Pantheon remote write. `overlay-delta` is refused before provider/Drush invocation.
+
+After the export attempt, PLT reports created/changed/deleted files under the configured path plus the complete Git status. If Drush fails after writing files, PLT preserves and reports the partial local state and exits nonzero rather than attempting an unsafe automatic rollback.
+
+See [`docs/config-export.md`](docs/config-export.md) for confirmation, Config Ignore, failure/retry, provider, and Git-safety details.
 
 ### Data pulls
 
@@ -265,7 +286,7 @@ Pantheon Tag routing remains the identity anchor for profile configuration. An e
 - `config-strategy=overlay-delta` for a protected site-specific delta/override set; and
 - a validated relative `config-path` appropriate to that project.
 
-Profile settings remain declarative. They do not themselves run Drupal, export config, start providers, pull data, or mutate Pantheon. Commands that consume them apply separate safety contracts. `pantheon-local readiness` consumes both strategy labels: full-export can complete provider/Drush inspection, while overlay-delta currently reports its protected boundary and fails closed when owning validation is unavailable.
+Profile settings remain declarative. They do not themselves run Drupal, export config, start providers, pull data, or mutate Pantheon. Commands that consume them apply separate safety contracts. `pantheon-local readiness` consumes both strategy labels: full-export can complete provider/Drush inspection, while overlay-delta currently reports its protected boundary and fails closed when owning validation is unavailable. `pantheon-local config export` consumes the same profile only as a separate explicit mutation action and supports `full-export` only.
 
 Examples:
 
@@ -316,6 +337,8 @@ Pantheon Local Tools is intentionally conservative around developer machines and
 - readiness verifies delegated full-export inspection does not change Git state;
 - overlay-delta readiness never interprets missing YAML, directory size, or file count as drift;
 - overlay-delta readiness does not invoke providers/Drush while owning validation is unavailable and exits nonzero rather than claiming readiness;
+- `pantheon-local config export` is explicit, confirmed/acknowledged, supports `full-export` only, and never runs as a readiness/setup/status/start side effect;
+- config export requires the configured export path to be Git-clean, never auto-stages/commits/pushes, and preserves/reports partial local changes after a failed provider export;
 - provider/project configuration remains provider-owned;
 - provider detection and Pantheon Tag routing fail on ambiguity rather than guessing;
 - unsupported Tag profile strategies and unsafe project-relative config paths fail instead of being guessed;
@@ -366,6 +389,7 @@ CI runs syntax validation, ShellCheck, and the shell integration suite on Ubuntu
 - [`docs/multidev.md`](docs/multidev.md) — Multidev checkout behavior and safety
 - [`docs/setup.md`](docs/setup.md) — provider-aware Drupal checkout bootstrap, failure/retry behavior, and local mutation boundaries
 - [`docs/readiness.md`](docs/readiness.md) — strategy-aware Drupal config readiness, overlay fail-closed reporting, Config Ignore, path containment, Git-integrity, and exit semantics
+- [`docs/config-export.md`](docs/config-export.md) — explicit full-export mutation, confirmation, Config Ignore authority, change reporting, and failure/retry behavior
 - [`docs/pull.md`](docs/pull.md) — database/files pull behavior and Git protection
 - [`docs/status.md`](docs/status.md) — read-only checkout inspection contract
 - [`docs/local-provider-architecture.md`](docs/local-provider-architecture.md) — DDEV/Lando boundary and provider architecture

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -13,7 +13,7 @@ Usage:
 Commands:
   pantheon-local config init [--root PATH] [--provider auto|ddev|lando]
       Guided first-run setup. With flags, configure root and/or provider
-      non-interactively.
+      noninteractively.
 
   pantheon-local config path
       Print the active configuration file path.
@@ -55,6 +55,12 @@ Commands:
 
   pantheon-local config tag profile list [TAG]
       List profile properties for one Tag or all configured Tag routes.
+
+  pantheon-local config export [--provider ddev|lando] [--yes]
+      Explicitly export tracked Drupal configuration for a validated full-export
+      profile. This mutates project files, requires a clean configured export
+      path, runs readiness first, and confirms unless --yes is supplied.
+      overlay-delta export is unsupported and fails before provider invocation.
 
   pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]
       Clone a Pantheon Multidev into an isolated local checkout. --dry-run
@@ -100,6 +106,7 @@ Examples:
   pantheon-local config tag set 'Example Group' example-group
   pantheon-local config tag profile set 'Example Group' config-strategy full-export
   pantheon-local config tag profile set 'Example Group' config-path config/sync
+  pantheon-local config export --yes
   pantheon-local multidev example.feature --dry-run
   pantheon-local setup --dry-run
   pantheon-local setup
@@ -112,6 +119,7 @@ Help:
   pantheon-local config help
   pantheon-local config init --help
   pantheon-local config tag profile --help
+  pantheon-local config export --help
   pantheon-local multidev --help
   pantheon-local setup --help
   pantheon-local readiness --help
@@ -159,6 +167,7 @@ VERSION_FILE="$PROJECT_ROOT/VERSION"
 LIBEXEC_DIR="$PROJECT_ROOT/libexec"
 CORE="$LIBEXEC_DIR/pantheon-local-core"
 PROFILE="$LIBEXEC_DIR/pantheon-local-config-profile"
+CONFIG_EXPORT="$LIBEXEC_DIR/pantheon-local-config-export"
 PULL="$LIBEXEC_DIR/pantheon-local-pull"
 READINESS="$LIBEXEC_DIR/pantheon-local-readiness"
 SETUP="$LIBEXEC_DIR/pantheon-local-setup"
@@ -196,6 +205,12 @@ case "$command" in
     ;;
   config)
     [ -x "$CORE" ] || die "core module is missing or not executable: $CORE"
+
+    if [ "${2:-}" = 'export' ]; then
+      [ -x "$CONFIG_EXPORT" ] || die "config-export module is missing or not executable: $CONFIG_EXPORT"
+      shift 2
+      exec "$CONFIG_EXPORT" "$@"
+    fi
 
     if [ "${2:-}" = 'tag' ] && [ "${3:-}" = 'profile' ]; then
       [ -x "$PROFILE" ] || die "tag-profile module is missing or not executable: $PROFILE"

--- a/bin/pantheon-local
+++ b/bin/pantheon-local
@@ -13,7 +13,7 @@ Usage:
 Commands:
   pantheon-local config init [--root PATH] [--provider auto|ddev|lando]
       Guided first-run setup. With flags, configure root and/or provider
-      noninteractively.
+      non-interactively.
 
   pantheon-local config path
       Print the active configuration file path.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,6 +45,7 @@ pantheon-local config tag profile get TAG PROPERTY
 pantheon-local config tag profile set TAG PROPERTY VALUE
 pantheon-local config tag profile unset TAG PROPERTY
 pantheon-local config tag profile list [TAG]
+pantheon-local config export [--provider ddev|lando] [--yes]
 
 pantheon-local multidev SITE.ENV
   --provider ddev|lando
@@ -69,9 +70,9 @@ pantheon-local version
 pantheon-local --version
 ```
 
-Running `pantheon-local` with no arguments shows the same top-level command reference as `pantheon-local help` / `pantheon-local --help`. Focused help routes such as `pantheon-local config help`, `pantheon-local config init --help`, `pantheon-local config tag profile --help`, `pantheon-local multidev --help`, `pantheon-local setup --help`, `pantheon-local readiness --help`, `pantheon-local pull --help`, and `pantheon-local status --help` are also supported discovery surfaces.
+Running `pantheon-local` with no arguments shows the same top-level command reference as `pantheon-local help` / `pantheon-local --help`. Focused help routes such as `pantheon-local config help`, `pantheon-local config init --help`, `pantheon-local config tag profile --help`, `pantheon-local config export --help`, `pantheon-local multidev --help`, `pantheon-local setup --help`, `pantheon-local readiness --help`, `pantheon-local pull --help`, and `pantheon-local status --help` are also supported discovery surfaces.
 
-New commands and additive options may be introduced in a compatible `0.1.x` release when they do not change existing command meaning. In particular, adding `pantheon-local setup` does not change `pantheon-local multidev --start`: `--start` continues to mean provider start only.
+New commands and additive options may be introduced in a compatible `0.1.x` release when they do not change existing command meaning. In particular, adding `pantheon-local setup` does not change `pantheon-local multidev --start`: `--start` continues to mean provider start only. Adding `pantheon-local config export` does not make setup, readiness, status, Tag matching, or provider start export configuration implicitly.
 
 ## Configuration contract
 
@@ -105,6 +106,8 @@ When stored configuration uses `provider=auto`, provider selection is based on p
 `pantheon-local setup` uses provider-owned command surfaces for provider start, Composer, and Drush. Composer is never silently replaced with host Composer when a supported provider owns the checkout runtime. The database refresh remains delegated through the existing provider-specific `pantheon-local pull --database-only` path.
 
 `pantheon-local readiness` uses provider-owned Drush only for strategy states whose readiness contract calls for it. Full-export readiness does not start or rebuild the provider; a runtime that cannot execute its required read-oriented Drush commands is an inspection failure rather than an implicit start request. Overlay-delta readiness does not invoke provider-owned commands while owning validation is unavailable.
+
+`pantheon-local config export` uses provider-owned Drush only after full-export preflight and explicit confirmation/acknowledgement. It does not start or rebuild the provider. A provider/runtime that cannot run the required readiness, module-state, or export command fails rather than falling back to host Drush.
 
 A provider-specific implementation detail may change in a patch release when the user-visible command contract and safety properties remain the same.
 
@@ -169,6 +172,38 @@ A later compatible implementation may add a reliable generic or explicitly confi
 
 Readiness records no successful-state metadata and performs no configuration export. It must not run `drush config:export`, `drush cex`, or an equivalent write merely because differences are reported.
 
+## Drupal configuration export contract
+
+`pantheon-local config export [--provider ddev|lando] [--yes]` is a separate, explicitly mutating tracked-source operation. Calling the command is explicit intent, and interactive execution still requires confirmation before export. `--yes` is the only documented non-interactive acknowledgement and skips only the PLT confirmation prompt.
+
+### Full-export mutation
+
+Export is supported only for a PLT-managed checkout whose recorded Tag resolves to `config-strategy=full-export` plus a valid existing `config-path` that remains physically inside the project root.
+
+Before mutation, PLT must:
+
+- require the configured export path to contain no pre-existing tracked or untracked Git changes;
+- resolve a supported provider without starting/rebuilding it;
+- complete the normal full-export readiness inspection successfully;
+- require Config Ignore enabled-module inspection to succeed rather than guessing mutation semantics;
+- print the mutation plan and require confirmation or `--yes`.
+
+Unrelated Git changes outside the configured export path do not block the command. They remain untouched and are included in the final repository-wide Git status.
+
+The mutation is provider-owned Drupal configuration export equivalent to `drush config:export -y`. PLT must not pass Drush options that stage or commit changes and must not itself stage, commit, or push the resulting files.
+
+Config Ignore remains Drupal runtime behavior. If `config_ignore` is enabled, PLT reports that fact but does not duplicate ignore patterns, export/import direction rules, or runtime deactivation behavior in PLT configuration. The actual Drupal/Config Ignore runtime remains authoritative for the provider-owned export.
+
+After the export attempt, PLT reports created/changed/deleted file counts under the configured export path and the complete final short Git status. Git `HEAD` must remain unchanged; an unexpected `HEAD` change is a failure because PLT did not request commit behavior.
+
+A provider-owned export can fail after writing files. PLT must preserve and report that partial local state, exit nonzero, and require the developer to review/resolve the resulting Git state before retrying. It must not automatically reset, stash, roll back, stage, commit, or hide those files.
+
+### Overlay-delta mutation
+
+`config-strategy=overlay-delta` is unsupported for generic config export. PLT must refuse before provider resolution or Drush invocation and must never flatten a protected partial override set with a generic full export.
+
+A future overlay mutation mechanism requires its own proven strategy-aware contract; the current fail-closed overlay readiness state does not authorize one.
+
 ## Safety contract
 
 A compatible `0.1.x` release must preserve these properties:
@@ -186,7 +221,7 @@ A compatible `0.1.x` release must preserve these properties:
 - validate all guided `config init` selections before writing so an invalid later value cannot leave a partial configuration update;
 - reject unsupported Tag `config-strategy` values instead of guessing future semantics;
 - reject unsafe/escaping Tag `config-path` values rather than treating them as project-relative paths;
-- reject readiness config directories that escape the Git project root through filesystem links;
+- reject readiness/config-export directories that escape the Git project root through filesystem links;
 - never make setting a Tag profile property implicitly create a Pantheon Tag route;
 - never interpret `overlay-delta` as permission to flatten or fully export Drupal configuration into the configured delta path;
 - never infer overlay drift from missing YAML, directory size, or file count;
@@ -197,8 +232,13 @@ A compatible `0.1.x` release must preserve these properties:
 - never make `multidev --start` silently perform the full Drupal setup pipeline;
 - never let `pantheon-local readiness` start/rebuild a provider or automatically export Drupal configuration;
 - never let full-export readiness silently substitute a different config path for the configured Tag profile;
-- never apply full-export readiness semantics to an `overlay-delta` profile; and
-- never report readiness success if a delegated full-export inspection changed Git `HEAD` or Git-visible working-tree state.
+- never apply full-export readiness semantics to an `overlay-delta` profile;
+- never report readiness success if a delegated full-export inspection changed Git `HEAD` or Git-visible working-tree state;
+- never let `pantheon-local config export` run implicitly from readiness, status, setup, `--start`, or Tag matching;
+- never export when the configured full-export path already has Git-visible changes;
+- never export an `overlay-delta` profile through generic `drush config:export` semantics;
+- never auto-stage, auto-commit, auto-push, or mutate remote Pantheon environments as part of config export; and
+- never hide or automatically roll back partial local YAML changes after a failed provider-owned config export.
 
 Safety tightening that converts a previously ambiguous/unsafe case into an explicit failure is considered compatible when documented in release notes.
 
@@ -212,7 +252,7 @@ In particular, the legacy `data.source` migration to independent database/files 
 
 Setup may add local troubleshooting keys for bootstrap status, failed/current step, recorded environment/provider, and update timestamp. `pantheon-local status` may display those fields. Their presence does not make checkout-local state a stable machine API or application configuration.
 
-Readiness consumes the recorded Pantheon Tag and provider identity when applicable but does not add a persistent readiness-result cache. The current Drupal/Git state is inspected fresh on each run.
+Readiness consumes the recorded Pantheon Tag and provider identity when applicable but does not add a persistent readiness-result cache. Config export consumes the same current profile/runtime state and does not add a persistent export-result cache; the resulting project-file state is represented by Git itself.
 
 ## Human-readable output
 
@@ -220,7 +260,7 @@ Normal command output is designed for developers and may gain additional labeled
 
 The text output is **not** yet a stable machine-readable API. Scripts that require a formal structured output format should wait for an explicitly documented JSON/porcelain interface rather than parsing incidental spacing.
 
-Exact non-zero numeric exit codes are not part of the `0.1.x` contract; success is exit `0`, failure is nonzero. A successful full-export readiness inspection may still report a review-required state, while overlay-delta currently exits nonzero when owning validation is unavailable.
+Exact non-zero numeric exit codes are not part of the `0.1.x` contract; success is exit `0`, failure is nonzero. A successful full-export readiness inspection may still report a review-required state, while overlay-delta currently exits nonzero when owning validation is unavailable. Config export exits nonzero for refused/cancelled/failed mutation paths, including partial provider-export failure after local files were written.
 
 ## Packaging contract
 

--- a/docs/config-export.md
+++ b/docs/config-export.md
@@ -1,0 +1,162 @@
+# Explicit Drupal configuration export
+
+`pantheon-local config export` is the explicit tracked-source mutation boundary for exporting Drupal configuration from a Pantheon Local Tools-managed checkout.
+
+Ordinary `pantheon-local readiness`, `pantheon-local status`, `pantheon-local setup`, Multidev checkout/start behavior, and Tag matching do **not** export configuration. A readiness report that shows differences never turns itself into a source mutation.
+
+## Command
+
+```bash
+pantheon-local config export [--provider ddev|lando] [--yes]
+```
+
+Interactive example:
+
+```bash
+pantheon-local config export
+```
+
+Explicit non-interactive acknowledgement:
+
+```bash
+pantheon-local config export --yes
+```
+
+Provider override:
+
+```bash
+pantheon-local config export --provider ddev --yes
+```
+
+`--yes` acknowledges the tracked-source mutation without an interactive prompt. Non-interactive execution without that acknowledgement fails before the export command is run.
+
+## Supported strategy
+
+### `full-export`
+
+Export is supported only when the checkout's recorded Pantheon Tag resolves to a valid `config-strategy=full-export` profile with an existing, physically contained `config-path`.
+
+The configured path remains project data. PLT never assumes `config/sync` or another literal directory.
+
+The actual mutation is provider-owned Drush:
+
+```text
+drush config:export -y
+```
+
+Drush documents `config:export` (`cex`) as exporting Drupal configuration to the site's configuration directory. PLT deliberately does not pass Drush `--add` or `--commit` and does not stage, commit, or push the result.
+
+Upstream reference:
+
+- Drush `config:export`: https://www.drush.org/13.x/commands/config_export/
+
+### `overlay-delta`
+
+Export is unsupported for `config-strategy=overlay-delta`.
+
+A protected overlay/delta directory is a partial override set, not a complete Drupal export. PLT refuses this strategy before provider resolution or provider/Drush invocation. It never substitutes a generic `cex`, flattens shared/base configuration into the delta, or treats the delta path as a complete sync directory.
+
+A future overlay mutation mechanism would require a separately proven owning-platform workflow. The current fail-closed readiness state does not establish one.
+
+## Preflight
+
+Before a full-export mutation, PLT performs this sequence:
+
+```text
+resolve recorded Tag/profile
+→ require full-export strategy
+→ validate configured path and physical project containment
+→ require configured export path to be Git-clean
+→ resolve provider
+→ run the normal full-export readiness inspection
+→ require Config Ignore module-state inspection to succeed
+→ show the mutation plan
+→ confirm interactively or require --yes
+→ provider-owned drush config:export -y
+→ report config-path changes and final Git status
+```
+
+The configured export path must have no pre-existing tracked or untracked Git changes. This is stricter than ordinary readiness on purpose: the post-export change report should represent the export operation rather than silently mixing newly generated YAML with unreviewed YAML that was already present.
+
+Unrelated dirty files elsewhere in the checkout do not block export. They are preserved and remain visible in the final repository-wide Git status.
+
+Readiness remains the inspection authority for the full-export runtime path. Before mutation it verifies that Drupal's runtime config-sync path corresponds to the profile's configured `config-path` and reports current configuration differences.
+
+## Config Ignore
+
+Config Ignore is Drupal runtime behavior, not a PLT strategy or duplicated PLT ruleset.
+
+Current Config Ignore 3.x can apply ignore behavior on export as well as import, and its modes/settings may distinguish those directions. PLT therefore does not copy ignore patterns into its own persistent configuration or try to reproduce Config Ignore's decision logic.
+
+Before mutation PLT requires enabled-module inspection to succeed:
+
+```text
+drush pm:list --type=module --status=enabled --field=name
+```
+
+If `config_ignore` is enabled, the mutation plan says so and reminds the user that Drupal/Config Ignore runtime export rules—including any runtime deactivation setting—remain authoritative. The provider-owned `drush config:export` then runs inside that actual Drupal runtime.
+
+If module-state inspection is unavailable, export fails closed rather than guessing whether Config Ignore semantics may affect the tracked-source mutation. This is intentionally stricter than read-only readiness, where an unavailable Config Ignore state is advisory.
+
+Upstream references:
+
+- Config Ignore: https://www.drupal.org/project/config_ignore
+- Config Ignore 3.4: https://www.drupal.org/project/config_ignore/releases/8.x-3.4
+- Drush module list: https://www.drush.org/13.x/commands/pm_list/
+
+## Confirmation
+
+The command itself is explicit, but interactive use still receives a final mutation plan and confirmation prompt.
+
+The plan includes:
+
+- checkout directory;
+- Pantheon Tag;
+- strategy;
+- configured export path;
+- provider;
+- Config Ignore module state;
+- the provider-owned Drush mutation; and
+- the fact that PLT will not commit or push.
+
+`--yes` is the documented automation acknowledgement. It skips only PLT's confirmation prompt; it does **not** skip profile validation, clean-path enforcement, readiness, Config Ignore inspection, provider errors, or post-export reporting.
+
+## Post-export report
+
+Because the configured export path is required to be clean before mutation, PLT can report the resulting config-path change classes relative to `HEAD`:
+
+```text
+Export change summary for config/project-export:
+  created: 2
+  changed: 3
+  deleted: 1
+```
+
+It then prints the complete repository-wide short Git status so unrelated pre-existing work is still visible.
+
+PLT does not stage files. It does not auto-commit, auto-push, or modify a remote Pantheon environment.
+
+Git `HEAD` is captured before and after the export. The command fails if `HEAD` changed, because PLT did not request Drush's commit behavior and an unexpected commit requires human inspection.
+
+## Failure and retry behavior
+
+A configuration export is not transactional. Provider-owned Drush can fail after writing some files.
+
+If `drush config:export` exits nonzero, PLT:
+
+1. does **not** claim success;
+2. reports the resulting config-path change summary;
+3. reports the final repository Git status;
+4. preserves whatever local files now exist;
+5. does not reset, stash, stage, commit, or roll back those files; and
+6. exits nonzero with guidance to inspect the local changes before retrying.
+
+That behavior avoids a more dangerous failure mode where an attempted automatic rollback could overwrite useful pre-existing or partially generated project state.
+
+A retry is appropriate only after the developer has reviewed and resolved the reported local Git state. Because the configured export path must be clean before a new attempt, a partial previous export cannot be silently overwritten by another run.
+
+## Remote boundary
+
+`pantheon-local config export` is a **local Drupal/project-file mutation**. PLT does not issue a Pantheon remote write, create/delete a Multidev, commit Git changes, or push a branch as part of this command.
+
+The provider must already be usable. PLT does not issue a provider start/rebuild command from config export.

--- a/docs/readiness.md
+++ b/docs/readiness.md
@@ -194,4 +194,4 @@ For `overlay-delta`, it also never runs `drush config:status` while the director
 
 Readiness does not write YAML, recommend a blind export merely because differences exist, or treat an overlay directory as incomplete because files are absent.
 
-Any future export capability is a separate explicit mutation boundary owned by #72.
+The separate `pantheon-local config export` command is the explicit tracked-source mutation boundary for validated `full-export` profiles. It is never invoked by readiness and does not support `overlay-delta`. See [`config-export.md`](config-export.md).

--- a/libexec/pantheon-local-config-export
+++ b/libexec/pantheon-local-config-export
@@ -242,7 +242,7 @@ export_command() {
         esac
         shift 2
         ;;
-      --yes|-y)
+      --yes)
         assume_yes=true
         shift
         ;;

--- a/libexec/pantheon-local-config-export
+++ b/libexec/pantheon-local-config-export
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM_NAME="pantheon-local"
+SCRIPT_DIR=$(unset CDPATH; cd -- "$(dirname -- "$0")" && pwd)
+PROFILE="$SCRIPT_DIR/pantheon-local-config-profile"
+READINESS="$SCRIPT_DIR/pantheon-local-readiness"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  pantheon-local config export [--provider ddev|lando] [--yes]
+
+Explicitly export Drupal configuration for the current Pantheon Local Tools-
+managed checkout when its matched Tag profile uses config-strategy=full-export.
+
+THIS COMMAND MUTATES PROJECT CONFIGURATION FILES.
+
+Preflight and mutation order:
+  1. Resolve the checkout's recorded Pantheon Tag and Tag profile.
+  2. Require config-strategy=full-export and a safe existing config-path.
+  3. Require the configured export path to have no pre-existing Git changes.
+  4. Run the normal full-export readiness inspection and print its report.
+  5. Require Config Ignore module-state inspection to succeed. PLT does not
+     duplicate Config Ignore rules; Drupal's runtime export behavior remains
+     authoritative when the module is enabled.
+  6. Require interactive confirmation, or --yes for a deliberate
+     non-interactive acknowledgement.
+  7. Run provider-owned drush config:export -y.
+  8. Report created/changed/deleted config files and the final Git status.
+
+Strategy support:
+  full-export    Supported after successful preflight and confirmation.
+  overlay-delta  Unsupported. PLT never applies a generic full export to a
+                 protected partial override set.
+
+Options:
+  --provider ddev|lando
+      Explicit provider selection. Otherwise checkout-local provider state or
+      unambiguous project configuration is used.
+
+  --yes
+      Acknowledge the tracked-source mutation without an interactive prompt.
+      Required for non-interactive use.
+
+Safety:
+  * No export occurs from readiness, status, setup, --start, or Tag matching.
+  * The configured export path must be Git-clean before mutation. Unrelated
+    working-tree changes elsewhere are preserved and do not block export.
+  * PLT does not pass Drush --add or --commit and never commits or pushes.
+  * PLT does not modify remote Pantheon environments.
+  * If export fails after writing files, PLT reports the resulting Git state
+    and exits nonzero; it does not roll back or hide partial local changes.
+  * Git HEAD must remain unchanged by export.
+
+Examples:
+  pantheon-local config export
+  pantheon-local config export --provider ddev
+  pantheon-local config export --yes
+USAGE
+}
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+git_root() {
+  git rev-parse --show-toplevel 2>/dev/null || die 'config export must be run inside a Git checkout'
+}
+
+git_dir_for_root() {
+  local root=$1 git_dir
+  git_dir=$(git -C "$root" rev-parse --git-dir)
+  case "$git_dir" in
+    /*) printf '%s\n' "$git_dir" ;;
+    *) printf '%s/%s\n' "$root" "$git_dir" ;;
+  esac
+}
+
+state_get() {
+  local state=$1 key=$2
+  [ -f "$state" ] || return 1
+  git config --file "$state" --get "$key" 2>/dev/null
+}
+
+provider_config_present() {
+  local root=$1 provider=$2
+  case "$provider" in
+    ddev) [ -f "$root/.ddev/config.yaml" ] ;;
+    lando) [ -f "$root/.lando.yml" ] ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_provider() {
+  local root=$1 has_ddev=false has_lando=false
+  provider_config_present "$root" ddev && has_ddev=true
+  provider_config_present "$root" lando && has_lando=true
+
+  case "$has_ddev:$has_lando" in
+    true:false) printf '%s\n' ddev ;;
+    false:true) printf '%s\n' lando ;;
+    true:true) die 'both DDEV and Lando project configuration were found; choose --provider explicitly' ;;
+    false:false) die 'neither DDEV nor Lando project configuration was found' ;;
+  esac
+}
+
+resolve_provider() {
+  local root=$1 state=$2 override=$3 recorded=''
+
+  if [ -n "$override" ]; then
+    provider_config_present "$root" "$override" || \
+      die "$override provider selected but its project configuration is missing"
+    printf '%s\n' "$override"
+    return
+  fi
+
+  recorded=$(state_get "$state" local.provider || true)
+  if [ -n "$recorded" ]; then
+    case "$recorded" in
+      ddev|lando)
+        provider_config_present "$root" "$recorded" || \
+          die "recorded provider $recorded no longer has project configuration"
+        printf '%s\n' "$recorded"
+        return
+        ;;
+      *) die "unsupported provider recorded in local state: $recorded" ;;
+    esac
+  fi
+
+  detect_provider "$root"
+}
+
+profile_get() {
+  local tag=$1 property=$2
+  [ -x "$PROFILE" ] || die "tag-profile module is missing or not executable: $PROFILE"
+  "$PROFILE" get "$tag" "$property"
+}
+
+require_config_directory() {
+  local root=$1 config_path=$2 root_physical config_physical
+
+  [ -d "$root/$config_path" ] || \
+    die "configured full-export config-path does not exist as a directory: $config_path"
+
+  root_physical=$(cd "$root" && pwd -P)
+  config_physical=$(cd "$root/$config_path" && pwd -P)
+  case "$config_physical" in
+    "$root_physical"/*) ;;
+    *) die "configured full-export config-path escapes the project root through filesystem links: $config_path" ;;
+  esac
+}
+
+run_drush_capture() {
+  local root=$1 provider=$2
+  shift 2
+  (cd "$root" && "$provider" drush "$@")
+}
+
+config_ignore_state() {
+  local root=$1 provider=$2 modules
+
+  if ! modules=$(run_drush_capture "$root" "$provider" pm:list --type=module --status=enabled --field=name 2>/dev/null); then
+    return 1
+  fi
+
+  if printf '%s\n' "$modules" | grep -Fx 'config_ignore' >/dev/null 2>&1; then
+    printf '%s\n' enabled
+  else
+    printf '%s\n' disabled
+  fi
+}
+
+count_nonempty_lines() {
+  local value=$1
+  if [ -z "$value" ]; then
+    printf '0\n'
+  else
+    printf '%s\n' "$value" | awk 'NF { count++ } END { print count + 0 }'
+  fi
+}
+
+report_git_state() {
+  local root=$1 config_path=$2 tracked untracked created_tracked created_count changed_count deleted_count final_status
+
+  tracked=$(git -C "$root" diff --name-status HEAD -- "$config_path")
+  untracked=$(git -C "$root" ls-files --others --exclude-standard -- "$config_path")
+  created_tracked=$(printf '%s\n' "$tracked" | awk '$1 == "A" { count++ } END { print count + 0 }')
+  created_count=$(count_nonempty_lines "$untracked")
+  created_count=$((created_count + created_tracked))
+  changed_count=$(printf '%s\n' "$tracked" | awk '$1 == "M" || $1 == "T" || $1 ~ /^R[0-9]+$/ || $1 ~ /^C[0-9]+$/ { count++ } END { print count + 0 }')
+  deleted_count=$(printf '%s\n' "$tracked" | awk '$1 == "D" { count++ } END { print count + 0 }')
+
+  printf '\nExport change summary for %s:\n' "$config_path"
+  printf '  created: %s\n' "$created_count"
+  printf '  changed: %s\n' "$changed_count"
+  printf '  deleted: %s\n' "$deleted_count"
+
+  final_status=$(git -C "$root" status --short)
+  printf '\nFinal Git status:\n'
+  if [ -n "$final_status" ]; then
+    printf '%s\n' "$final_status"
+  else
+    printf '(clean)\n'
+  fi
+}
+
+confirm_export() {
+  local assume_yes=$1 answer=''
+
+  if [ "$assume_yes" = true ]; then
+    printf 'Confirmation:          acknowledged by --yes\n'
+    return
+  fi
+
+  [ -t 0 ] || die 'non-interactive config export requires --yes acknowledgement'
+  printf 'Proceed with configuration export? [y/N] ' >&2
+  IFS= read -r answer || answer=''
+  case "$answer" in
+    y|Y|yes|YES|Yes) ;;
+    *) die 'configuration export cancelled; no export command was run' ;;
+  esac
+}
+
+export_command() {
+  local provider_override='' assume_yes=false root git_dir state tag strategy config_path provider
+  local path_state readiness_output ignore_state head_before head_after export_status=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --provider)
+        [ "$#" -ge 2 ] || die '--provider requires ddev or lando'
+        provider_override=$2
+        case "$provider_override" in
+          ddev|lando) ;;
+          *) die '--provider must be ddev or lando' ;;
+        esac
+        shift 2
+        ;;
+      --yes|-y)
+        assume_yes=true
+        shift
+        ;;
+      -h|--help|help)
+        usage
+        return
+        ;;
+      --*) die "unknown config export option: $1" ;;
+      *) die 'usage: pantheon-local config export [--provider ddev|lando] [--yes]' ;;
+    esac
+  done
+
+  require_command git
+  require_command grep
+  require_command awk
+  root=$(git_root)
+  git_dir=$(git_dir_for_root "$root")
+  state="$git_dir/pantheon-local-tools/state"
+  [ -f "$state" ] || \
+    die 'config export requires a Pantheon Local Tools-managed checkout with recorded Pantheon Tag state'
+
+  tag=$(state_get "$state" pantheon.tag || true)
+  [ -n "$tag" ] || \
+    die 'config export requires checkout-local pantheon.tag state so the matching profile can be resolved'
+
+  strategy=$(profile_get "$tag" config-strategy)
+  config_path=$(profile_get "$tag" config-path)
+  case "$strategy" in
+    full-export) ;;
+    overlay-delta)
+      die 'overlay-delta config export is unsupported; refusing to apply a generic full export to a protected partial override set'
+      ;;
+    *) die "unsupported config strategy for export: $strategy" ;;
+  esac
+
+  require_config_directory "$root" "$config_path"
+
+  path_state=$(git -C "$root" status --porcelain --untracked-files=normal -- "$config_path")
+  [ -z "$path_state" ] || \
+    die "configured export path has pre-existing Git changes; review, commit, stash, or otherwise resolve $config_path before exporting"
+
+  provider=$(resolve_provider "$root" "$state" "$provider_override")
+  require_command "$provider"
+  [ -x "$READINESS" ] || die "readiness module is missing or not executable: $READINESS"
+
+  printf 'Pantheon Local Tools config export preflight\n\n'
+  if ! readiness_output=$("$READINESS" --provider "$provider" 2>&1); then
+    printf '%s\n' "$readiness_output"
+    die 'full-export readiness preflight failed; configuration was not exported'
+  fi
+  printf '%s\n' "$readiness_output"
+
+  if ! ignore_state=$(config_ignore_state "$root" "$provider"); then
+    die 'Config Ignore module-state inspection failed; refusing tracked-source mutation rather than guessing runtime export semantics'
+  fi
+
+  printf '\nExport mutation plan\n'
+  printf 'Directory:             %s\n' "$root"
+  printf 'Pantheon Tag:          %s\n' "$tag"
+  printf 'Config strategy:       full-export\n'
+  printf 'Configured config path:%s%s\n' ' ' "$config_path"
+  printf 'Provider:              %s\n' "$provider"
+  printf 'Config Ignore module:  %s\n' "$ignore_state"
+  printf 'Mutation:              provider-owned drush config:export -y\n'
+  printf 'Git commit/push:       not performed\n'
+
+  if [ "$ignore_state" = enabled ]; then
+    printf '\nConfig Ignore is enabled. Drupal/Config Ignore runtime export rules, including any runtime deactivation setting, remain authoritative; PLT does not duplicate those rules.\n'
+  fi
+
+  confirm_export "$assume_yes"
+
+  head_before=$(git -C "$root" rev-parse HEAD)
+  printf '\nRunning provider-owned Drupal configuration export...\n'
+  if ! (cd "$root" && "$provider" drush config:export -y); then
+    export_status=1
+  fi
+  head_after=$(git -C "$root" rev-parse HEAD)
+
+  report_git_state "$root" "$config_path"
+
+  if [ "$head_after" != "$head_before" ]; then
+    die 'configuration export unexpectedly changed Git HEAD; PLT did not request a commit, so inspect repository state before continuing'
+  fi
+
+  if [ "$export_status" -ne 0 ]; then
+    die 'provider-owned drush config:export failed; inspect the reported local Git changes before retrying'
+  fi
+
+  printf '\nConfiguration export completed. Review the reported Git changes; PLT did not commit or push them.\n'
+}
+
+export_command "$@"

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -41,6 +41,7 @@ install -d "$APP_ROOT/bin" "$APP_ROOT/libexec" "$STAGE/usr/bin" "$DOC_ROOT" "$CO
 install -m 0755 "$REPO_ROOT/bin/pantheon-local" "$APP_ROOT/bin/pantheon-local"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-core" "$APP_ROOT/libexec/pantheon-local-core"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-config-profile" "$APP_ROOT/libexec/pantheon-local-config-profile"
+install -m 0755 "$REPO_ROOT/libexec/pantheon-local-config-export" "$APP_ROOT/libexec/pantheon-local-config-export"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-provider-url" "$APP_ROOT/libexec/pantheon-local-provider-url"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-pull" "$APP_ROOT/libexec/pantheon-local-pull"
 install -m 0755 "$REPO_ROOT/libexec/pantheon-local-readiness" "$APP_ROOT/libexec/pantheon-local-readiness"

--- a/tests/test-config-export.sh
+++ b/tests/test-config-export.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." && pwd)
+CLI=${CLI:-"$REPO_ROOT/bin/pantheon-local"}
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+MOCK_BIN="$TMP_ROOT/bin"
+MOCK_LOG="$TMP_ROOT/provider.log"
+mkdir -p "$MOCK_BIN"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "expected output to contain [$2], got [$1]" ;; esac; }
+assert_not_contains() { case "$1" in *"$2"*) fail "expected output not to contain [$2], got [$1]" ;; *) ;; esac; }
+assert_file_contains() { grep -F "$2" "$1" >/dev/null 2>&1 || fail "expected $1 to contain [$2]"; }
+assert_file_not_contains() { if [ -f "$1" ] && grep -F "$2" "$1" >/dev/null 2>&1; then fail "expected $1 not to contain [$2]"; fi; }
+
+cat > "$MOCK_BIN/provider-mock" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+provider=$(basename "$0")
+line=$provider
+for arg in "$@"; do line="$line|$arg"; done
+printf '%s\n' "$line" >> "${MOCK_LOG:?}"
+
+case "$line" in
+  "$provider|drush|core:status|--field=config-sync")
+    printf '%s\n' "${MOCK_RUNTIME_CONFIG_PATH:?}"
+    ;;
+  "$provider|drush|config:status|--format=list")
+    [ -z "${MOCK_CONFIG_STATUS:-}" ] || printf '%s\n' "$MOCK_CONFIG_STATUS"
+    ;;
+  "$provider|drush|pm:list|--type=module|--status=enabled|--field=name")
+    [ "${MOCK_PM_FAIL:-false}" != true ] || exit 10
+    printf '%s\n' "${MOCK_MODULES:-node}"
+    ;;
+  "$provider|drush|config:export|-y")
+    case "${MOCK_EXPORT_MODE:-success}" in
+      success)
+        printf 'exported: true\n' >> "${MOCK_EXPORT_PATH:?}/system.site.yml"
+        printf 'created: true\n' > "${MOCK_EXPORT_PATH:?}/created.yml"
+        rm -f "${MOCK_EXPORT_PATH:?}/obsolete.yml"
+        ;;
+      nochange)
+        ;;
+      fail-partial)
+        printf 'partial: true\n' >> "${MOCK_EXPORT_PATH:?}/system.site.yml"
+        exit 9
+        ;;
+      *) exit 11 ;;
+    esac
+    ;;
+esac
+MOCK
+chmod +x "$MOCK_BIN/provider-mock"
+ln -s provider-mock "$MOCK_BIN/lando"
+ln -s provider-mock "$MOCK_BIN/ddev"
+
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_LOG
+export PANTHEON_LOCAL_CONFIG="$TMP_ROOT/plt-config"
+
+reset_mocks() {
+  : > "$MOCK_LOG"
+  unset MOCK_CONFIG_STATUS MOCK_MODULES MOCK_PM_FAIL MOCK_EXPORT_MODE MOCK_EXPORT_PATH MOCK_RUNTIME_CONFIG_PATH || true
+}
+
+create_repo() {
+  local path=$1 provider=$2 tag=$3 strategy=$4 config_path=$5 directory
+  mkdir -p "$path/$config_path"
+  git -C "$path" init -q
+  git -C "$path" config user.name 'Test User'
+  git -C "$path" config user.email 'test@example.com'
+  printf 'fixture\n' > "$path/README.md"
+  printf 'uuid: fixture\n' > "$path/$config_path/system.site.yml"
+  printf 'obsolete: true\n' > "$path/$config_path/obsolete.yml"
+
+  case "$provider" in
+    lando) printf 'name: example-site\nrecipe: pantheon\n' > "$path/.lando.yml" ;;
+    ddev)
+      mkdir -p "$path/.ddev"
+      printf 'name: example-site\ntype: drupal11\n' > "$path/.ddev/config.yaml"
+      ;;
+    *) fail "unknown provider fixture: $provider" ;;
+  esac
+
+  git -C "$path" add .
+  git -C "$path" commit -qm 'Create config export fixture'
+  mkdir -p "$path/.git/pantheon-local-tools"
+  git config --file "$path/.git/pantheon-local-tools/state" pantheon.tag "$tag"
+  git config --file "$path/.git/pantheon-local-tools/state" local.provider "$provider"
+
+  directory=$(basename "$path")
+  bash "$CLI" config tag set "$tag" "$directory"
+  bash "$CLI" config tag profile set "$tag" config-strategy "$strategy"
+  bash "$CLI" config tag profile set "$tag" config-path "$config_path"
+}
+
+capture_failure() {
+  local repo=$1
+  shift
+  local output status
+  set +e
+  output=$(cd "$repo" && bash "$CLI" config export "$@" 2>&1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "expected config export to fail for $repo"
+  printf '%s\n' "$output"
+}
+
+export_help=$(bash "$CLI" config export --help)
+assert_contains "$export_help" 'pantheon-local config export [--provider ddev|lando] [--yes]'
+assert_contains "$export_help" 'THIS COMMAND MUTATES PROJECT CONFIGURATION FILES.'
+assert_contains "$export_help" 'full-export'
+assert_contains "$export_help" 'overlay-delta  Unsupported.'
+assert_contains "$export_help" 'configured export path to have no pre-existing Git changes'
+assert_contains "$export_help" 'Config Ignore'
+assert_contains "$export_help" 'never commits or pushes'
+assert_contains "$export_help" 'Required for non-interactive use.'
+
+# A deliberate full-export mutation succeeds, preserves unrelated dirty work,
+# leaves HEAD/index untouched, and reports the exact config-path change classes.
+SUCCESS="$TMP_ROOT/export-success"
+create_repo "$SUCCESS" lando 'Full Export Mutation' full-export config/project-export
+printf 'unrelated local notes\n' > "$SUCCESS/notes.txt"
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/app/config/project-export'
+export MOCK_CONFIG_STATUS='system.site'
+export MOCK_EXPORT_PATH="$SUCCESS/config/project-export"
+export MOCK_EXPORT_MODE=success
+head_before=$(git -C "$SUCCESS" rev-parse HEAD)
+success_output=$(cd "$SUCCESS" && bash "$CLI" config export --yes)
+head_after=$(git -C "$SUCCESS" rev-parse HEAD)
+[ "$head_after" = "$head_before" ] || fail 'config export changed Git HEAD'
+git -C "$SUCCESS" diff --cached --quiet || fail 'config export staged files unexpectedly'
+assert_contains "$success_output" 'Pantheon Local Tools config export preflight'
+assert_contains "$success_output" 'Drupal configuration:  differences detected'
+assert_contains "$success_output" 'Export mutation plan'
+assert_contains "$success_output" 'Config strategy:       full-export'
+assert_contains "$success_output" 'Config Ignore module:  disabled'
+assert_contains "$success_output" 'Mutation:              provider-owned drush config:export -y'
+assert_contains "$success_output" 'Confirmation:          acknowledged by --yes'
+assert_contains "$success_output" 'Export change summary for config/project-export:'
+assert_contains "$success_output" 'created: 1'
+assert_contains "$success_output" 'changed: 1'
+assert_contains "$success_output" 'deleted: 1'
+assert_contains "$success_output" 'Final Git status:'
+assert_contains "$success_output" 'notes.txt'
+assert_contains "$success_output" 'Configuration export completed.'
+assert_file_contains "$MOCK_LOG" 'lando|drush|config:export|-y'
+assert_file_not_contains "$MOCK_LOG" '--commit'
+assert_file_not_contains "$MOCK_LOG" '--add'
+
+# Existing Git changes inside the configured export path fail before any provider call.
+DIRTY_PATH="$TMP_ROOT/dirty-path"
+create_repo "$DIRTY_PATH" lando 'Dirty Export Path' full-export config/dirty-export
+printf 'manual: change\n' >> "$DIRTY_PATH/config/dirty-export/system.site.yml"
+reset_mocks
+dirty_output=$(capture_failure "$DIRTY_PATH" --yes)
+assert_contains "$dirty_output" 'configured export path has pre-existing Git changes'
+[ ! -s "$MOCK_LOG" ] || fail 'dirty export path invoked provider commands'
+
+# Overlay export is categorically unsupported and fails before provider resolution/invocation.
+OVERLAY="$TMP_ROOT/overlay"
+create_repo "$OVERLAY" lando 'Protected Overlay Export' overlay-delta config/site-overrides
+reset_mocks
+overlay_output=$(capture_failure "$OVERLAY" --yes)
+assert_contains "$overlay_output" 'overlay-delta config export is unsupported'
+assert_contains "$overlay_output" 'protected partial override set'
+[ ! -s "$MOCK_LOG" ] || fail 'overlay config export invoked provider commands'
+
+# Invalid provider syntax fails at the public boundary before provider calls.
+INVALID_PROVIDER="$TMP_ROOT/invalid-provider"
+create_repo "$INVALID_PROVIDER" lando 'Invalid Provider Export' full-export config/export
+reset_mocks
+invalid_provider_output=$(capture_failure "$INVALID_PROVIDER" --provider other --yes)
+assert_contains "$invalid_provider_output" '--provider must be ddev or lando'
+[ ! -s "$MOCK_LOG" ] || fail 'invalid provider export invoked provider commands'
+
+# Non-interactive use requires explicit --yes and never reaches cex without it.
+CONFIRM="$TMP_ROOT/confirmation"
+create_repo "$CONFIRM" lando 'Confirmation Export' full-export config/export
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/app/config/export'
+export MOCK_CONFIG_STATUS='system.site'
+export MOCK_EXPORT_PATH="$CONFIRM/config/export"
+export MOCK_EXPORT_MODE=nochange
+confirm_output=$(capture_failure "$CONFIRM")
+assert_contains "$confirm_output" 'non-interactive config export requires --yes acknowledgement'
+assert_file_not_contains "$MOCK_LOG" 'config:export'
+
+# Enabled Config Ignore is reported, but its runtime export rules remain Drupal authority.
+IGNORE="$TMP_ROOT/config-ignore"
+create_repo "$IGNORE" lando 'Config Ignore Export' full-export config/export
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/app/config/export'
+export MOCK_CONFIG_STATUS='system.site'
+export MOCK_MODULES=$'node\nconfig_ignore'
+export MOCK_EXPORT_PATH="$IGNORE/config/export"
+export MOCK_EXPORT_MODE=nochange
+ignore_output=$(cd "$IGNORE" && bash "$CLI" config export --yes)
+assert_contains "$ignore_output" 'Config Ignore module:  enabled'
+assert_contains "$ignore_output" 'runtime export rules'
+assert_contains "$ignore_output" 'PLT does not duplicate those rules.'
+assert_file_contains "$MOCK_LOG" 'lando|drush|config:export|-y'
+
+# Export uses a stricter Config Ignore preflight than readiness: unknown module
+# state blocks mutation rather than guessing.
+UNKNOWN_IGNORE="$TMP_ROOT/unknown-ignore"
+create_repo "$UNKNOWN_IGNORE" lando 'Unknown Ignore Export' full-export config/export
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/app/config/export'
+export MOCK_CONFIG_STATUS='system.site'
+export MOCK_PM_FAIL=true
+export MOCK_EXPORT_PATH="$UNKNOWN_IGNORE/config/export"
+unknown_ignore_output=$(capture_failure "$UNKNOWN_IGNORE" --yes)
+assert_contains "$unknown_ignore_output" 'Config Ignore:         unavailable'
+assert_contains "$unknown_ignore_output" 'Config Ignore module-state inspection failed'
+assert_file_not_contains "$MOCK_LOG" 'config:export'
+
+# A failed readiness preflight prevents export.
+READINESS_FAIL="$TMP_ROOT/readiness-fail"
+create_repo "$READINESS_FAIL" lando 'Readiness Failure Export' full-export config/expected
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/app/config/other'
+export MOCK_EXPORT_PATH="$READINESS_FAIL/config/expected"
+readiness_fail_output=$(capture_failure "$READINESS_FAIL" --yes)
+assert_contains "$readiness_fail_output" 'does not match Drupal runtime config-sync path'
+assert_contains "$readiness_fail_output" 'full-export readiness preflight failed'
+assert_file_not_contains "$MOCK_LOG" 'config:export'
+
+# Provider export failure can leave partial local changes. PLT reports them,
+# leaves them in place, and fails without committing or pretending rollback.
+PARTIAL="$TMP_ROOT/partial-failure"
+create_repo "$PARTIAL" lando 'Partial Export Failure' full-export config/export
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/app/config/export'
+export MOCK_CONFIG_STATUS='system.site'
+export MOCK_EXPORT_PATH="$PARTIAL/config/export"
+export MOCK_EXPORT_MODE=fail-partial
+partial_output=$(capture_failure "$PARTIAL" --yes)
+assert_contains "$partial_output" 'Export change summary for config/export:'
+assert_contains "$partial_output" 'changed: 1'
+assert_contains "$partial_output" 'provider-owned drush config:export failed'
+grep -F 'partial: true' "$PARTIAL/config/export/system.site.yml" >/dev/null 2>&1 || fail 'partial export fixture change was unexpectedly rolled back'
+git -C "$PARTIAL" diff --cached --quiet || fail 'failed export staged files unexpectedly'
+
+# Explicit DDEV selection follows the same mutation contract.
+DDEV="$TMP_ROOT/ddev-export"
+create_repo "$DDEV" ddev 'DDEV Full Export' full-export config/export
+reset_mocks
+export MOCK_RUNTIME_CONFIG_PATH='/var/www/html/config/export'
+export MOCK_EXPORT_PATH="$DDEV/config/export"
+export MOCK_EXPORT_MODE=nochange
+ddev_output=$(cd "$DDEV" && bash "$CLI" config export --provider ddev --yes)
+assert_contains "$ddev_output" 'Provider:              ddev'
+assert_contains "$ddev_output" 'created: 0'
+assert_contains "$ddev_output" 'changed: 0'
+assert_contains "$ddev_output" 'deleted: 0'
+assert_file_contains "$MOCK_LOG" 'ddev|drush|config:export|-y'
+
+printf 'config export tests passed\n'

--- a/tests/test-debian-package.sh
+++ b/tests/test-debian-package.sh
@@ -29,6 +29,7 @@ dpkg-deb -x "$PACKAGE" "$EXTRACT"
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/bin/pantheon-local" ] || fail 'packaged command is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-core" ] || fail 'packaged core module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-config-profile" ] || fail 'packaged tag-profile module is missing or not executable'
+[ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-config-export" ] || fail 'packaged config-export module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-provider-url" ] || fail 'packaged URL module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-pull" ] || fail 'packaged pull module is missing or not executable'
 [ -x "$EXTRACT/usr/lib/pantheon-local-tools/libexec/pantheon-local-readiness" ] || fail 'packaged readiness module is missing or not executable'
@@ -53,6 +54,7 @@ assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config get provider)" 'ddev'
 "$EXTRACT/usr/bin/pantheon-local" config tag profile set 'Package Example' config-path config/sync
 assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config tag profile get 'Package Example' config-strategy)" 'full-export'
 assert_eq "$("$EXTRACT/usr/bin/pantheon-local" config tag profile get 'Package Example' config-path)" 'config/sync'
+"$EXTRACT/usr/bin/pantheon-local" config export --help | grep -F 'MUTATES PROJECT CONFIGURATION FILES' >/dev/null 2>&1 || fail 'packaged config export help is unavailable'
 "$EXTRACT/usr/bin/pantheon-local" setup --help | grep -F 'pantheon-local setup' >/dev/null 2>&1 || fail 'packaged setup help is unavailable'
 "$EXTRACT/usr/bin/pantheon-local" readiness --help | grep -F 'pantheon-local readiness' >/dev/null 2>&1 || fail 'packaged readiness help is unavailable'
 

--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -27,6 +27,7 @@ for expected in \
   'pantheon-local config tag profile set TAG PROPERTY VALUE' \
   'pantheon-local config tag profile unset TAG PROPERTY' \
   'pantheon-local config tag profile list [TAG]' \
+  'pantheon-local config export [--provider ddev|lando] [--yes]' \
   'config-strategy  full-export or overlay-delta' \
   'config-path      Relative project configuration path such as config/sync' \
   'pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]' \
@@ -38,6 +39,7 @@ for expected in \
   'pantheon-local --version' \
   'auto   Detect from project configuration after checkout' \
   "pantheon-local config tag profile set 'Example Group' config-strategy full-export" \
+  'pantheon-local config export --yes' \
   'pantheon-local multidev example.feature --dry-run' \
   'pantheon-local setup --dry-run' \
   'pantheon-local readiness' \
@@ -45,13 +47,16 @@ for expected in \
 do
   assert_contains "$help_output" "$expected"
 done
-assert_contains "$help_output" 'overlay-delta reports its protected partial path'
+assert_contains "$help_output" 'Explicitly export tracked Drupal configuration'
+assert_contains "$help_output" 'mutates project files'
+assert_contains "$help_output" 'overlay-delta export is unsupported'
 assert_contains "$help_output" 'fails closed while owning validation is unavailable'
 
 config_help=$(bash "$CLI" config help)
 assert_contains "$config_help" 'pantheon-local config init [--root PATH] [--provider auto|ddev|lando]'
 assert_contains "$config_help" 'pantheon-local config tag set TAG DIRECTORY'
 assert_contains "$config_help" 'pantheon-local config tag profile set TAG PROPERTY VALUE'
+assert_contains "$config_help" 'pantheon-local config export [--provider ddev|lando] [--yes]'
 
 tag_help=$(bash "$CLI" config tag help)
 assert_contains "$tag_help" 'pantheon-local config tag profile list [TAG]'
@@ -64,6 +69,18 @@ profile_help=$(bash "$CLI" config tag profile --help)
 assert_contains "$profile_help" 'pantheon-local config tag profile get TAG PROPERTY'
 assert_contains "$profile_help" 'config-strategy  full-export or overlay-delta'
 assert_contains "$profile_help" 'Setting a profile property never creates a tag route.'
+
+export_help=$(bash "$CLI" config export --help)
+assert_contains "$export_help" 'pantheon-local config export [--provider ddev|lando] [--yes]'
+assert_contains "$export_help" 'THIS COMMAND MUTATES PROJECT CONFIGURATION FILES.'
+assert_contains "$export_help" 'configured export path to have no pre-existing Git changes'
+assert_contains "$export_help" 'Run the normal full-export readiness inspection'
+assert_contains "$export_help" 'Config Ignore'
+assert_contains "$export_help" 'overlay-delta  Unsupported.'
+assert_contains "$export_help" 'Required for non-interactive use.'
+assert_contains "$export_help" 'PLT does not pass Drush --add or --commit'
+assert_contains "$export_help" 'does not modify remote Pantheon environments'
+assert_contains "$export_help" 'reports the resulting Git state'
 
 multidev_help=$(bash "$CLI" multidev --help)
 assert_contains "$multidev_help" 'pantheon-local multidev SITE.ENV [--provider ddev|lando] [--group NAME] [--dry-run] [--start]'

--- a/tests/test-homebrew-package.sh
+++ b/tests/test-homebrew-package.sh
@@ -88,6 +88,7 @@ FORMULA_CLI="$PREFIX/bin/pantheon-local"
 [ -x "$PREFIX/libexec/bin/pantheon-local" ] || fail 'Homebrew command payload is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-core" ] || fail 'Homebrew core module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-config-profile" ] || fail 'Homebrew tag-profile module is missing'
+[ -x "$PREFIX/libexec/libexec/pantheon-local-config-export" ] || fail 'Homebrew config-export module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-provider-url" ] || fail 'Homebrew provider URL module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-pull" ] || fail 'Homebrew pull module is missing'
 [ -x "$PREFIX/libexec/libexec/pantheon-local-readiness" ] || fail 'Homebrew readiness module is missing'
@@ -98,6 +99,7 @@ FORMULA_CLI="$PREFIX/bin/pantheon-local"
 expected="pantheon-local $VERSION"
 assert_eq "$("$FORMULA_CLI" --version)" "$expected"
 assert_eq "$("$FORMULA_CLI" version)" "$expected"
+"$FORMULA_CLI" config export --help | grep -F 'MUTATES PROJECT CONFIGURATION FILES' >/dev/null 2>&1 || fail 'Homebrew config export help is unavailable'
 "$FORMULA_CLI" setup --help | grep -F 'pantheon-local setup' >/dev/null 2>&1 || fail 'Homebrew setup help is unavailable'
 "$FORMULA_CLI" readiness --help | grep -F 'pantheon-local readiness' >/dev/null 2>&1 || fail 'Homebrew readiness help is unavailable'
 

--- a/tests/test-release-artifacts.sh
+++ b/tests/test-release-artifacts.sh
@@ -45,6 +45,7 @@ tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/VERSION" >/dev/null 2>&1 || fail 'VER
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/bin/pantheon-local" >/dev/null 2>&1 || fail 'CLI missing from source archive'
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-core" >/dev/null 2>&1 || fail 'core module missing from source archive'
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-config-profile" >/dev/null 2>&1 || fail 'tag-profile module missing from source archive'
+tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-config-export" >/dev/null 2>&1 || fail 'config-export module missing from source archive'
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-readiness" >/dev/null 2>&1 || fail 'readiness module missing from source archive'
 tar -tzf "$SOURCE_ONE" | grep -Fx "$PREFIX/libexec/pantheon-local-setup" >/dev/null 2>&1 || fail 'setup module missing from source archive'
 if tar -tzf "$SOURCE_ONE" | grep -E '/\.git(/|$)|/dist(/|$)|/\.agents(/|$)' >/dev/null 2>&1; then
@@ -56,6 +57,7 @@ mkdir -p "$EXTRACT"
 tar -xzf "$SOURCE_ONE" -C "$EXTRACT"
 expected="pantheon-local $VERSION"
 assert_eq "$(bash "$EXTRACT/$PREFIX/bin/pantheon-local" --version)" "$expected"
+bash "$EXTRACT/$PREFIX/bin/pantheon-local" config export --help | grep -F 'MUTATES PROJECT CONFIGURATION FILES' >/dev/null 2>&1 || fail 'source archive config export help is unavailable'
 bash "$EXTRACT/$PREFIX/bin/pantheon-local" setup --help | grep -F 'pantheon-local setup' >/dev/null 2>&1 || fail 'source archive setup help is unavailable'
 bash "$EXTRACT/$PREFIX/bin/pantheon-local" readiness --help | grep -F 'pantheon-local readiness' >/dev/null 2>&1 || fail 'source archive readiness help is unavailable'
 


### PR DESCRIPTION
## Summary

Implements #72 as a separate, unmistakably mutating configuration-export boundary.

- adds `pantheon-local config export [--provider ddev|lando] [--yes]`;
- supports validated `full-export` profiles only;
- refuses `overlay-delta` before provider resolution/Drush invocation;
- requires the configured export path to be Git-clean before mutation while preserving unrelated dirty work elsewhere;
- runs the normal full-export readiness inspection before mutation;
- requires Config Ignore module-state inspection to succeed and leaves Drupal/Config Ignore runtime export semantics authoritative;
- confirms interactively or requires the explicit `--yes` acknowledgement for non-interactive use;
- runs provider-owned `drush config:export -y` without Drush staging/commit options;
- reports created/changed/deleted config files plus final repository Git status;
- never stages, commits, pushes, or mutates a remote Pantheon environment;
- preserves and reports partial local YAML changes when provider export fails instead of attempting an unsafe rollback.

## Safety boundaries

`readiness`, `status`, ordinary `setup`, Multidev `--start`, and Tag matching remain non-exporting. Config export does not start/rebuild the provider. An unexpected Git `HEAD` change is a failure.

The only documented non-interactive PLT acknowledgement is `--yes`; no hidden `-y` alias is exposed.

## Validation

Focused tests cover:

- full-export success with exact created/changed/deleted reporting;
- unrelated dirty working-tree preservation;
- dirty configured-export-path refusal before provider calls;
- overlay-delta refusal before provider calls;
- invalid provider handling;
- non-interactive acknowledgement enforcement;
- Config Ignore enabled and unavailable states;
- readiness-preflight failure;
- provider export failure after partial file mutation;
- DDEV/Lando provider parity;
- unchanged Git HEAD/index and no auto-stage/commit behavior;
- command/help contract;
- Debian, Homebrew, and release-archive packaging presence.

Documentation includes README, focused `docs/config-export.md`, readiness boundary, compatibility contract, and changelog updates. Public examples remain generic.

Closes #72.