### PR TITLE
Harden v0.1.2 APT shell-safety regression coverage

### DIFF
--- a/.github/workflows/validate-published-apt.yml
+++ b/.github/workflows/validate-published-apt.yml
@@ -204,11 +204,30 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Seed isolated shell startup files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          shell_home="$RUNNER_TEMP/pantheon-local-tools-shell-home"
+          snapshot="$RUNNER_TEMP/pantheon-local-tools-shell-before"
+          mkdir -p "$shell_home" "$snapshot"
+
+          for rc in \
+            .bashrc .bash_profile .bash_login .profile \
+            .zshenv .zprofile .zshrc .zlogin .zlogout; do
+            printf 'sentinel:%s\n' "$rc" > "$shell_home/$rc"
+            cp "$shell_home/$rc" "$snapshot/$rc"
+          done
+
+          printf 'APT_TEST_HOME=%s\n' "$shell_home" >> "$GITHUB_ENV"
+          printf 'APT_SHELL_SNAPSHOT=%s\n' "$snapshot" >> "$GITHUB_ENV"
+
       - name: Install through the one-command APT bootstrap
         shell: bash
         run: |
           set -euo pipefail
-          install_output=$(bash ./install-apt.sh 2>&1)
+          install_output=$(HOME="$APT_TEST_HOME" bash ./install-apt.sh 2>&1)
           printf '%s\n' "$install_output"
           case "$install_output" in
             *"doesn't support architecture"*)
@@ -234,11 +253,33 @@ jobs:
             grep -qx 'install ok installed'
           /usr/bin/pantheon-local --version
 
+          for rc in \
+            .bashrc .bash_profile .bash_login .profile \
+            .zshenv .zprofile .zshrc .zlogin .zlogout; do
+            cmp -s "$APT_SHELL_SNAPSHOT/$rc" "$APT_TEST_HOME/$rc" || {
+              printf 'shell startup file changed during APT bootstrap: %s\n' \
+                "$rc" >&2
+              exit 1
+            }
+          done
+
       - name: Remove bootstrap validation state
         if: always()
         shell: bash
         run: |
+          set -euo pipefail
+
           sudo apt-get remove --yes pantheon-local-tools || true
           sudo rm -f \
             /etc/apt/sources.list.d/pantheon-local-tools.sources \
             /etc/apt/keyrings/pantheon-local-tools.gpg
+
+          for rc in \
+            .bashrc .bash_profile .bash_login .profile \
+            .zshenv .zprofile .zshrc .zlogin .zlogout; do
+            cmp -s "$APT_SHELL_SNAPSHOT/$rc" "$APT_TEST_HOME/$rc" || {
+              printf 'shell startup file changed during APT install/remove cycle: %s\n' \
+                "$rc" >&2
+              exit 1
+            }
+          done

--- a/tests/test-debian-package.sh
+++ b/tests/test-debian-package.sh
@@ -22,6 +22,14 @@ assert_eq "$(dpkg-deb -f "$PACKAGE" Version)" "$VERSION"
 assert_eq "$(dpkg-deb -f "$PACKAGE" Architecture)" 'all'
 assert_eq "$(dpkg-deb -f "$PACKAGE" Depends)" 'bash, git'
 
+CONTROL_EXTRACT="$TMP_ROOT/control"
+mkdir -p "$CONTROL_EXTRACT"
+dpkg-deb -e "$PACKAGE" "$CONTROL_EXTRACT"
+for maintainer_file in preinst postinst prerm postrm config triggers; do
+  [ ! -e "$CONTROL_EXTRACT/$maintainer_file" ] ||
+    fail "Debian package unexpectedly contains maintainer hook: $maintainer_file"
+done
+
 EXTRACT="$TMP_ROOT/root"
 mkdir -p "$EXTRACT"
 dpkg-deb -x "$PACKAGE" "$EXTRACT"

--- a/tests/test-install-apt.sh
+++ b/tests/test-install-apt.sh
@@ -17,6 +17,23 @@ assert_file_contains() {
     fail "expected $file to contain [$expected]"
 }
 
+SHELL_HOME="$TMP_ROOT/home"
+SHELL_SNAPSHOT="$TMP_ROOT/shell-startup-before"
+mkdir -p "$SHELL_HOME" "$SHELL_SNAPSHOT"
+for rc in .bashrc .bash_profile .bash_login .profile .zshenv .zprofile .zshrc .zlogin .zlogout; do
+  printf 'sentinel:%s\n' "$rc" > "$SHELL_HOME/$rc"
+  cp "$SHELL_HOME/$rc" "$SHELL_SNAPSHOT/$rc"
+done
+export HOME="$SHELL_HOME"
+
+assert_shell_startup_files_unchanged() {
+  for rc in .bashrc .bash_profile .bash_login .profile .zshenv .zprofile .zshrc .zlogin .zlogout; do
+    [ -f "$HOME/$rc" ] || fail "APT installer removed shell startup file: $HOME/$rc"
+    cmp -s "$SHELL_SNAPSHOT/$rc" "$HOME/$rc" ||
+      fail "APT installer modified shell startup file: $HOME/$rc"
+  done
+}
+
 MOCK_BIN="$TMP_ROOT/mock-bin"
 CALL_LOG="$TMP_ROOT/calls.log"
 CAPTURE_SOURCE="$TMP_ROOT/pantheon-local-tools.sources"
@@ -117,6 +134,7 @@ assert_file_contains "$CAPTURE_SOURCE" 'Suites: stable'
 assert_file_contains "$CAPTURE_SOURCE" 'Components: main'
 assert_file_contains "$CAPTURE_SOURCE" 'Architectures: all'
 assert_file_contains "$CAPTURE_SOURCE" 'Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg'
+assert_shell_startup_files_unchanged
 
 # A fingerprint mismatch must fail before any privileged write or APT action.
 : > "$CALL_LOG"
@@ -127,6 +145,7 @@ fi
 if grep -Eq '^(sudo |apt-get |install )' "$CALL_LOG"; then
   fail 'fingerprint mismatch reached a privileged write or APT action'
 fi
+assert_shell_startup_files_unchanged
 
 # The helper is intentionally Linux/APT-only; macOS users should use Homebrew.
 : > "$CALL_LOG"
@@ -134,6 +153,7 @@ if MOCK_UNAME='Darwin' bash "$REPO_ROOT/install-apt.sh" >/dev/null 2>&1; then
   fail 'installer accepted an unsupported non-Linux host'
 fi
 [ ! -s "$CALL_LOG" ] || fail 'unsupported host executed external setup actions'
+assert_shell_startup_files_unchanged
 
 # Root execution must not require sudo.
 : > "$CALL_LOG"
@@ -144,5 +164,6 @@ if grep -Eq '^sudo ' "$CALL_LOG"; then
 fi
 assert_file_contains "$CALL_LOG" 'apt-get update'
 assert_file_contains "$CALL_LOG" 'apt-get install --yes pantheon-local-tools'
+assert_shell_startup_files_unchanged
 
 printf 'APT install tests passed\n'


### PR DESCRIPTION
Release-safety hardening for #80.

This PR adds explicit regression coverage for a known maintainer-risk boundary before v0.1.2 publication:

- seed common Bash/Zsh startup files in an isolated HOME and assert the APT installer leaves them byte-for-byte unchanged across success and failure paths;
- assert the built Debian package contains no maintainer hooks (`preinst`, `postinst`, `prerm`, `postrm`, `config`, `triggers`) that could mutate user shell state during package installation.

Runtime/package contents are otherwise unchanged. No real user HOME is touched by these tests.