### PR TITLE
Add reusable disposable WSL2 APT upgrade validation harness

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,3 +63,28 @@ jobs:
           for test in tests/test-*.sh; do
             bash "$test"
           done
+
+  validate-powershell-release-harness:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Parse PowerShell release harness
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          $path = (Resolve-Path 'packaging/release/validate-wsl2-apt-upgrade.ps1').Path
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            $path,
+            [ref] $tokens,
+            [ref] $errors
+          ) | Out-Null
+
+          if ($errors.Count -gt 0) {
+            $errors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
+          Write-Host 'PowerShell release harness syntax: PASS'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -150,6 +150,8 @@ Before advertising upgrade support, exercise a real previous-version -> current-
 
 Run real WSL/WSL2 release-package validation only in an explicitly named disposable distribution/home. Never use a maintainer's normal WSL distro or normal home for install/upgrade/reinstall/remove proof. Before any package operation, seed or snapshot the common Bash/Zsh startup files (`.bashrc`, `.bash_profile`, `.bash_login`, `.profile`, `.zshenv`, `.zprofile`, `.zshrc`, `.zlogin`, and `.zlogout`) plus representative user-owned Pantheon Local Tools configuration. Verify those bytes remain unchanged after prerequisite installation, previous-version installation, upgrade, current-version reinstall, and package removal. Fail closed if the runtime distro identity does not match the explicitly requested disposable target, never unregister the target automatically, and preserve evidence on failure until the result is reviewed.
 
+Use the checked-in harness and disposable-distro lifecycle in [`Disposable WSL2 APT release validation`](wsl2-apt-release-validation.md) for this proof.
+
 The project website and signed hosted APT repository share this GitHub Pages origin:
 
 ```text

--- a/docs/wsl2-apt-release-validation.md
+++ b/docs/wsl2-apt-release-validation.md
@@ -49,6 +49,18 @@ pwsh -NoProfile -File .\packaging\release\validate-wsl2-apt-upgrade.ps1 `
   -ConfirmDisposableDistro
 ```
 
+If Windows execution policy refuses an unsigned `.ps1` — commonly when invoking a repository checkout through a `\\wsl.localhost\...` UNC path — do not weaken the machine/user policy. Start a child PowerShell process with a process-local bypass instead:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\packaging\release\validate-wsl2-apt-upgrade.ps1 `
+  -FromVersion '0.1.1' `
+  -ToVersion '0.1.2' `
+  -DistroName $DistroName `
+  -ConfirmDisposableDistro
+```
+
+`-ExecutionPolicy Bypass` on this `pwsh` invocation applies only to that child process; it does not persistently change the current user or machine execution policy. Review the checked-in script before using the bypass.
+
 For a later release, replace the example versions with the actual previous and current published stable versions.
 
 Optional OS assertions can pin the expected disposable image when a release tracker requires a specific WSL image:

--- a/docs/wsl2-apt-release-validation.md
+++ b/docs/wsl2-apt-release-validation.md
@@ -1,0 +1,124 @@
+# Disposable WSL2 APT release validation
+
+Use this procedure for the real WSL2 previous-version -> current-version APT upgrade proof required by [`docs/releasing.md`](releasing.md).
+
+The checked-in harness is:
+
+```text
+packaging/release/validate-wsl2-apt-upgrade.ps1
+```
+
+It is maintainer release-validation tooling, not an end-user installer. Run it from Windows PowerShell 7 against a separately created disposable WSL2 distribution. Never target a normal development distro or normal home directory.
+
+## 1. Create a disposable WSL2 distribution
+
+First inspect the installed/available WSL distributions from PowerShell:
+
+```powershell
+wsl.exe --version
+wsl.exe --list --verbose
+wsl.exe --list --online
+```
+
+Create a separate WSL2 distribution with an explicit name and location. This example uses Ubuntu 26.04; select a currently available Debian-family distribution appropriate to the release gate when that version is no longer current:
+
+```powershell
+$DistroName = 'PLT-release-test'
+
+wsl.exe --install Ubuntu-26.04 `
+  --name $DistroName `
+  --location "$HOME\WSL\$DistroName" `
+  --version 2 `
+  --no-launch `
+  --web-download
+
+wsl.exe --list --verbose
+```
+
+Do not make the disposable distribution the Windows WSL default. The validation harness refuses to target whichever distribution is currently marked as default.
+
+## 2. Run the reusable upgrade proof
+
+Run the harness from a repository checkout so it can resolve the canonical APT repository URL and primary archive fingerprint from the checked-in `install-apt.sh` metadata:
+
+```powershell
+pwsh -NoProfile -File .\packaging\release\validate-wsl2-apt-upgrade.ps1 `
+  -FromVersion '0.1.1' `
+  -ToVersion '0.1.2' `
+  -DistroName $DistroName `
+  -ConfirmDisposableDistro
+```
+
+For a later release, replace the example versions with the actual previous and current published stable versions.
+
+Optional OS assertions can pin the expected disposable image when a release tracker requires a specific WSL image:
+
+```powershell
+  -ExpectedOsId ubuntu `
+  -ExpectedOsVersion '26.04'
+```
+
+The harness fails closed before PLT package operations unless all of the following are true:
+
+- the explicit target distro exists and `wsl.exe --list --verbose` reports WSL version 2;
+- the target is not the current default WSL distribution;
+- `-ConfirmDisposableDistro` was supplied;
+- the Linux runtime's `WSL_DISTRO_NAME` exactly matches the requested target;
+- the Linux kernel reports WSL2;
+- optional OS assertions match when supplied;
+- PLT is not already installed and the dedicated PLT APT source/keyring are not already present;
+- no prior evidence directory for the same version pair is present.
+
+Before any PLT package operation, the harness creates/snapshots these disposable-user startup files:
+
+```text
+.bashrc
+.bash_profile
+.bash_login
+.profile
+.zshenv
+.zprofile
+.zshrc
+.zlogin
+.zlogout
+```
+
+It then:
+
+1. installs only the APT validation prerequisites inside the disposable distro;
+2. resolves the project-owned APT URL and primary fingerprint from `install-apt.sh` and verifies the downloaded archive key;
+3. verifies both requested package versions are present in the signed public repository and that the current version is the live candidate;
+4. installs the requested previous version and verifies the CLI version;
+5. creates representative user-owned PLT configuration;
+6. upgrades through APT to the requested current version and verifies CLI/config/shell-file preservation;
+7. reinstalls the current version and rechecks preservation;
+8. removes the package and verifies user configuration plus shell startup files remain intact;
+9. writes and prints sanitized public-safe evidence; and
+10. removes only the dedicated PLT APT source/keyring on success.
+
+The PowerShell-to-Linux payload is transferred as UTF-8 bytes through Base64 so Windows CRLF/nested quoting cannot alter the embedded Bash program.
+
+## 3. Review evidence before cleanup
+
+The harness intentionally does **not** unregister the disposable distro. On success it prints the public-safe evidence and retains the full validation state inside the disposable distribution under:
+
+```text
+/root/pantheon-local-tools-wsl-validation/<FROM>-to-<TO>/
+```
+
+On failure it leaves the state/source/keyring/package state as observed and exits nonzero. Review the retained evidence before retrying or deleting the target. Prefer a fresh disposable distro for a clean release proof rather than silently overwriting failed evidence.
+
+Do not publish machine-specific paths, local usernames, private site/account identifiers, credentials, or other private host state in a public issue. The generated `evidence.txt` intentionally omits the Windows machine name and explicit WSL distro name.
+
+## 4. Remove the disposable distro manually
+
+Only after the validation result has been reviewed and any required public-safe evidence has been recorded, remove the disposable target from PowerShell:
+
+```powershell
+wsl.exe --list --verbose
+wsl.exe --terminate $DistroName
+wsl.exe --unregister $DistroName
+wsl.exe --list --verbose
+```
+
+`wsl.exe --unregister` permanently deletes that distribution's Linux filesystem. Verify `$DistroName` immediately before running it. The checked-in harness never performs this cleanup automatically.

--- a/packaging/release/validate-wsl2-apt-upgrade.ps1
+++ b/packaging/release/validate-wsl2-apt-upgrade.ps1
@@ -1,0 +1,488 @@
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9][0-9A-Za-z.+:~_-]*$')]
+    [string]$FromVersion,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9][0-9A-Za-z.+:~_-]*$')]
+    [string]$ToVersion,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[A-Za-z0-9._-]+$')]
+    [string]$DistroName,
+
+    [switch]$ConfirmDisposableDistro,
+
+    [ValidatePattern('^$|^[a-z0-9._-]+$')]
+    [string]$ExpectedOsId = '',
+
+    [ValidatePattern('^$|^[0-9A-Za-z._-]+$')]
+    [string]$ExpectedOsVersion = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $ConfirmDisposableDistro) {
+    throw 'Refusing package validation without -ConfirmDisposableDistro. Use only a disposable WSL2 distribution/home.'
+}
+
+if ($FromVersion -eq $ToVersion) {
+    throw 'FromVersion and ToVersion must identify different published package versions.'
+}
+
+if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+    throw 'wsl.exe was not found. Run this harness from Windows PowerShell 7 on a WSL-capable host.'
+}
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$InstallAptPath = Join-Path $RepoRoot 'install-apt.sh'
+if (-not (Test-Path -LiteralPath $InstallAptPath -PathType Leaf)) {
+    throw "Cannot locate project-owned APT metadata at $InstallAptPath"
+}
+
+$InstallApt = Get-Content -LiteralPath $InstallAptPath -Raw
+$FingerprintMatch = [regex]::Match(
+    $InstallApt,
+    "(?m)^APT_PRIMARY_FINGERPRINT='([A-F0-9]{40})'\s*$"
+)
+if (-not $FingerprintMatch.Success) {
+    throw 'Could not resolve APT_PRIMARY_FINGERPRINT from install-apt.sh.'
+}
+$ExpectedFingerprint = $FingerprintMatch.Groups[1].Value
+
+$RepositoryMatch = [regex]::Match(
+    $InstallApt,
+    "(?m)^APT_REPOSITORY_URL='([^']+)'\s*$"
+)
+if (-not $RepositoryMatch.Success) {
+    throw 'Could not resolve APT_REPOSITORY_URL from install-apt.sh.'
+}
+$AptRepositoryUrl = $RepositoryMatch.Groups[1].Value
+
+$VerboseOutput = & wsl.exe --list --verbose 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw 'Unable to inspect installed WSL distributions.'
+}
+
+$DefaultDistro = $null
+$TargetFound = $false
+$TargetVersion = $null
+
+foreach ($RawLine in $VerboseOutput) {
+    $Line = (($RawLine -replace "`0", '').Trim())
+    if ([string]::IsNullOrWhiteSpace($Line)) {
+        continue
+    }
+
+    $IsDefault = $Line.StartsWith('*')
+    if ($IsDefault) {
+        $Line = $Line.Substring(1).TrimStart()
+    }
+
+    $Parts = $Line -split '\s+'
+    if ($Parts.Count -lt 3) {
+        continue
+    }
+
+    $Name = $Parts[0]
+    $Version = $Parts[-1]
+
+    if ($IsDefault) {
+        $DefaultDistro = $Name
+    }
+
+    if ([System.StringComparer]::OrdinalIgnoreCase.Equals($Name, $DistroName)) {
+        $TargetFound = $true
+        $TargetVersion = $Version
+    }
+}
+
+if (-not $TargetFound) {
+    throw "Disposable target distro '$DistroName' is not installed."
+}
+
+if ($TargetVersion -ne '2') {
+    throw "Disposable target distro '$DistroName' is not WSL2 according to 'wsl.exe --list --verbose'."
+}
+
+if (
+    $null -ne $DefaultDistro -and
+    [System.StringComparer]::OrdinalIgnoreCase.Equals($DefaultDistro, $DistroName)
+) {
+    throw "Refusing to target the current default WSL distribution '$DistroName'. Create/select a separate disposable distro."
+}
+
+Write-Host '=== Pantheon Local Tools disposable WSL2 APT upgrade validation ==='
+Write-Host "Target distro: $DistroName"
+Write-Host "Upgrade: $FromVersion -> $ToVersion"
+Write-Host 'The target must be disposable. The harness never unregisters a distribution.'
+Write-Host
+
+$LinuxScript = @'
+set -Eeuo pipefail
+
+FROM_VERSION=${PLT_FROM_VERSION:?}
+TO_VERSION=${PLT_TO_VERSION:?}
+EXPECTED_DISTRO=${PLT_EXPECTED_DISTRO:?}
+EXPECTED_FINGERPRINT=${PLT_EXPECTED_FINGERPRINT:?}
+APT_REPOSITORY_URL=${PLT_APT_REPOSITORY_URL:?}
+EXPECTED_OS_ID=${PLT_EXPECTED_OS_ID:-}
+EXPECTED_OS_VERSION=${PLT_EXPECTED_OS_VERSION:-}
+
+TEST_USER='plt-test'
+HOME_DIR='/home/plt-test'
+STATE_ROOT='/root/pantheon-local-tools-wsl-validation'
+STATE_DIR="$STATE_ROOT/${FROM_VERSION}-to-${TO_VERSION}"
+SHELL_SNAPSHOT="$STATE_DIR/shell-before"
+BASELINE_HASHES="$STATE_DIR/shell-baseline.sha256"
+CONFIG="$HOME_DIR/.config/pantheon-local-tools/config"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+stage() {
+  printf '\n=== %s ===\n' "$*"
+}
+
+assert_shell_unchanged() {
+  local rc
+  for rc in \
+    .bashrc .bash_profile .bash_login .profile \
+    .zshenv .zprofile .zshrc .zlogin .zlogout
+  do
+    cmp -s "$SHELL_SNAPSHOT/$rc" "$HOME_DIR/$rc" || \
+      fail "shell startup file changed: $rc"
+  done
+}
+
+assert_config_unchanged() {
+  local current
+  current=$(sha256sum "$CONFIG" | awk '{print $1}')
+  [ "$current" = "$CONFIG_SHA" ] || fail 'user config bytes changed'
+  [ "$(git config --file "$CONFIG" --get local.provider)" = 'ddev' ] || \
+    fail 'user config provider changed'
+}
+
+trap 'printf "\nValidation stopped at line %s. Evidence/state remains inside %s.\n" "$LINENO" "$STATE_DIR" >&2' ERR
+
+stage 'SAFETY BOUNDARY'
+
+[ "${WSL_DISTRO_NAME:-}" = "$EXPECTED_DISTRO" ] || \
+  fail "wrong WSL distro: expected $EXPECTED_DISTRO, got ${WSL_DISTRO_NAME:-unknown}"
+
+[ "$(id -u)" -eq 0 ] || fail 'validation payload must run as root inside the disposable distro'
+
+grep -qi 'microsoft-standard-WSL2' /proc/version || \
+  fail 'target is not reporting a WSL2 kernel'
+
+. /etc/os-release
+printf 'distro identity: matched requested disposable target\n'
+printf 'os: %s\n' "$PRETTY_NAME"
+printf 'kernel: %s\n' "$(uname -r)"
+
+if [ -n "$EXPECTED_OS_ID" ] && [ "$ID" != "$EXPECTED_OS_ID" ]; then
+  fail "unexpected OS id: expected $EXPECTED_OS_ID, got $ID"
+fi
+
+if [ -n "$EXPECTED_OS_VERSION" ] && [ "$VERSION_ID" != "$EXPECTED_OS_VERSION" ]; then
+  fail "unexpected OS version: expected $EXPECTED_OS_VERSION, got $VERSION_ID"
+fi
+
+if dpkg-query -W -f='${Status}\n' pantheon-local-tools 2>/dev/null |
+   grep -qx 'install ok installed'
+then
+  fail 'pantheon-local-tools is already installed; use a clean disposable distro for release proof'
+fi
+
+[ ! -e /etc/apt/sources.list.d/pantheon-local-tools.sources ] || \
+  fail 'Pantheon Local Tools APT source already exists; review the disposable distro before retrying'
+[ ! -e /etc/apt/keyrings/pantheon-local-tools.gpg ] || \
+  fail 'Pantheon Local Tools APT keyring already exists; review the disposable distro before retrying'
+[ ! -e "$STATE_DIR" ] || \
+  fail "validation state already exists at $STATE_DIR; preserve/review it before retrying"
+
+mkdir -p "$STATE_DIR" "$SHELL_SNAPSHOT"
+
+stage 'DISPOSABLE USER + SHELL BASELINE'
+
+if ! id "$TEST_USER" >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash "$TEST_USER"
+fi
+
+mkdir -p "$HOME_DIR"
+
+for rc in \
+  .bashrc .bash_profile .bash_login .profile \
+  .zshenv .zprofile .zshrc .zlogin .zlogout
+do
+  printf 'PLT-WSL-VALIDATION-SENTINEL:%s\n' "$rc" > "$HOME_DIR/$rc"
+  cp -- "$HOME_DIR/$rc" "$SHELL_SNAPSHOT/$rc"
+done
+
+chown -R "$TEST_USER:$TEST_USER" "$HOME_DIR"
+
+sha256sum \
+  "$HOME_DIR/.bashrc" \
+  "$HOME_DIR/.bash_profile" \
+  "$HOME_DIR/.bash_login" \
+  "$HOME_DIR/.profile" \
+  "$HOME_DIR/.zshenv" \
+  "$HOME_DIR/.zprofile" \
+  "$HOME_DIR/.zshrc" \
+  "$HOME_DIR/.zlogin" \
+  "$HOME_DIR/.zlogout" \
+  | tee "$BASELINE_HASHES"
+
+assert_shell_unchanged
+echo 'shell baseline: PASS'
+
+stage 'APT PREREQUISITES'
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install --yes ca-certificates curl gnupg
+
+dpkg --compare-versions "$FROM_VERSION" lt "$TO_VERSION" || \
+  fail "FromVersion must compare lower than ToVersion under Debian version semantics: $FROM_VERSION -> $TO_VERSION"
+
+assert_shell_unchanged
+echo 'shell files after prerequisite packages: PASS'
+
+stage 'VERIFY ARCHIVE KEY'
+
+KEYRING="$STATE_DIR/pantheon-local-tools-archive-keyring.gpg"
+
+curl --fail --silent --show-error --location \
+  "$APT_REPOSITORY_URL/pantheon-local-tools-archive-keyring.gpg" \
+  --output "$KEYRING"
+
+ACTUAL_FINGERPRINT=$(
+  gpg --batch --show-keys --with-colons "$KEYRING" |
+    awk -F: '$1 == "fpr" && !found { print $10; found = 1 }'
+)
+
+[ "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT" ] || \
+  fail "archive fingerprint mismatch: $ACTUAL_FINGERPRINT"
+
+printf 'archive fingerprint: %s\n' "$ACTUAL_FINGERPRINT"
+
+install -d -m 0755 /etc/apt/keyrings /etc/apt/sources.list.d
+install -m 0644 \
+  "$KEYRING" \
+  /etc/apt/keyrings/pantheon-local-tools.gpg
+
+cat > /etc/apt/sources.list.d/pantheon-local-tools.sources <<EOF
+Types: deb
+URIs: $APT_REPOSITORY_URL
+Suites: stable
+Components: main
+Architectures: all
+Signed-By: /etc/apt/keyrings/pantheon-local-tools.gpg
+EOF
+
+APT_UPDATE_OUTPUT=$(apt-get update 2>&1)
+printf '%s\n' "$APT_UPDATE_OUTPUT"
+
+case "$APT_UPDATE_OUTPUT" in
+  *"doesn't support architecture"*)
+    fail 'APT emitted an unsupported-architecture notice'
+    ;;
+esac
+
+stage 'VERIFY PUBLISHED VERSIONS'
+
+apt-cache policy pantheon-local-tools
+apt-cache madison pantheon-local-tools
+
+apt-cache madison pantheon-local-tools | awk '{print $3}' | grep -Fxq "$FROM_VERSION" || \
+  fail "published repository does not expose $FROM_VERSION"
+
+apt-cache madison pantheon-local-tools | awk '{print $3}' | grep -Fxq "$TO_VERSION" || \
+  fail "published repository does not expose $TO_VERSION"
+
+CANDIDATE=$(
+  apt-cache policy pantheon-local-tools |
+    awk '/Candidate:/ && !found { print $2; found = 1 }'
+)
+
+[ "$CANDIDATE" = "$TO_VERSION" ] || \
+  fail "expected live candidate $TO_VERSION, got $CANDIDATE"
+
+echo "candidate: $CANDIDATE"
+
+stage "INSTALL PUBLISHED $FROM_VERSION"
+
+apt-get install --yes "pantheon-local-tools=$FROM_VERSION"
+
+[ "$(dpkg-query -W -f='${Version}' pantheon-local-tools)" = "$FROM_VERSION" ] || \
+  fail "dpkg did not install $FROM_VERSION"
+
+[ "$(/usr/bin/pantheon-local --version)" = "pantheon-local $FROM_VERSION" ] || \
+  fail "CLI did not report $FROM_VERSION"
+
+printf 'installed version: %s\n' "$FROM_VERSION"
+assert_shell_unchanged
+echo "shell files after $FROM_VERSION install: PASS"
+
+stage 'CREATE USER-OWNED CONFIG'
+
+install -d -o "$TEST_USER" -g "$TEST_USER" -m 0700 "$(dirname "$CONFIG")"
+
+runuser -u "$TEST_USER" -- \
+  env HOME="$HOME_DIR" PANTHEON_LOCAL_CONFIG="$CONFIG" \
+  /usr/bin/pantheon-local config set provider ddev
+
+PROVIDER=$(
+  runuser -u "$TEST_USER" -- \
+    env HOME="$HOME_DIR" PANTHEON_LOCAL_CONFIG="$CONFIG" \
+    /usr/bin/pantheon-local config get provider
+)
+
+[ "$PROVIDER" = 'ddev' ] || fail 'user config did not read back provider ddev'
+[ -f "$CONFIG" ] || fail 'user config file was not created'
+
+CONFIG_SHA=$(sha256sum "$CONFIG" | awk '{print $1}')
+CONFIG_OWNER=$(stat -c '%U:%G' "$CONFIG")
+
+[ "$CONFIG_OWNER" = "$TEST_USER:$TEST_USER" ] || \
+  fail "unexpected config owner: $CONFIG_OWNER"
+
+printf 'config provider: %s\n' "$PROVIDER"
+printf 'config owner: %s\n' "$CONFIG_OWNER"
+printf 'config sha256: %s\n' "$CONFIG_SHA"
+
+stage "APT UPGRADE $FROM_VERSION -> $TO_VERSION"
+
+apt-get install --yes --only-upgrade "pantheon-local-tools=$TO_VERSION"
+
+[ "$(dpkg-query -W -f='${Version}' pantheon-local-tools)" = "$TO_VERSION" ] || \
+  fail "dpkg did not upgrade to $TO_VERSION"
+
+[ "$(/usr/bin/pantheon-local --version)" = "pantheon-local $TO_VERSION" ] || \
+  fail "CLI did not report $TO_VERSION"
+
+assert_config_unchanged
+assert_shell_unchanged
+
+printf 'upgraded version: %s\n' "$TO_VERSION"
+echo 'config after upgrade: PASS'
+echo 'shell files after upgrade: PASS'
+
+stage "REINSTALL $TO_VERSION"
+
+apt-get install --yes --reinstall "pantheon-local-tools=$TO_VERSION"
+
+[ "$(/usr/bin/pantheon-local --version)" = "pantheon-local $TO_VERSION" ] || \
+  fail "CLI did not remain at $TO_VERSION after reinstall"
+
+assert_config_unchanged
+assert_shell_unchanged
+
+echo 'reinstall: PASS'
+echo 'config after reinstall: PASS'
+echo 'shell files after reinstall: PASS'
+
+stage 'REMOVE PACKAGE'
+
+apt-get remove --yes pantheon-local-tools
+hash -r
+
+if dpkg-query -W -f='${Status}\n' pantheon-local-tools 2>/dev/null |
+   grep -qx 'install ok installed'
+then
+  fail 'package remains installed after remove'
+fi
+
+[ ! -e /usr/bin/pantheon-local ] || fail '/usr/bin/pantheon-local remains after remove'
+[ ! -e /usr/lib/pantheon-local-tools ] || \
+  fail '/usr/lib/pantheon-local-tools remains after remove'
+
+assert_config_unchanged
+assert_shell_unchanged
+
+echo 'remove: PASS'
+echo 'user config after remove: PASS'
+echo 'shell files after remove: PASS'
+
+stage 'WRITE PUBLIC-SAFE EVIDENCE'
+
+cat > "$STATE_DIR/evidence.txt" <<EOF
+Pantheon Local Tools disposable WSL2 APT upgrade validation: PASS
+Target identity: explicitly named non-default disposable WSL2 distro verified
+OS: $PRETTY_NAME
+Kernel: $(uname -r)
+APT archive primary fingerprint: $ACTUAL_FINGERPRINT
+Published versions present: $FROM_VERSION, $TO_VERSION
+Live candidate: $TO_VERSION
+Initial package install: $FROM_VERSION PASS
+APT upgrade $FROM_VERSION -> $TO_VERSION: PASS
+CLI version after upgrade: pantheon-local $TO_VERSION
+User-owned config provider: ddev
+User-owned config preservation: PASS
+Bash/Zsh startup-file preservation: PASS
+$TO_VERSION reinstall: PASS
+Package remove: PASS
+User-owned config after remove: PASS
+EOF
+
+cat "$STATE_DIR/evidence.txt"
+
+stage 'CLEAN REPOSITORY CONFIG ONLY'
+
+rm -f \
+  /etc/apt/sources.list.d/pantheon-local-tools.sources \
+  /etc/apt/keyrings/pantheon-local-tools.gpg
+
+apt-get update >/dev/null
+
+assert_config_unchanged
+assert_shell_unchanged
+
+echo
+echo '=== WSL2 APT UPGRADE VALIDATION PASS ==='
+echo "Evidence: $STATE_DIR/evidence.txt"
+'@
+
+$Bytes = [System.Text.Encoding]::UTF8.GetBytes($LinuxScript)
+$Encoded = [Convert]::ToBase64String($Bytes)
+$LinuxCommand = "printf '%s' '$Encoded' | base64 -d | bash"
+
+$WslArguments = @(
+    '-d', $DistroName,
+    '-u', 'root',
+    '--',
+    'env',
+    "PLT_FROM_VERSION=$FromVersion",
+    "PLT_TO_VERSION=$ToVersion",
+    "PLT_EXPECTED_DISTRO=$DistroName",
+    "PLT_EXPECTED_FINGERPRINT=$ExpectedFingerprint",
+    "PLT_APT_REPOSITORY_URL=$AptRepositoryUrl",
+    "PLT_EXPECTED_OS_ID=$ExpectedOsId",
+    "PLT_EXPECTED_OS_VERSION=$ExpectedOsVersion",
+    'bash', '-lc', $LinuxCommand
+)
+
+& wsl.exe @WslArguments
+if ($LASTEXITCODE -ne 0) {
+    throw "WSL2 APT validation failed inside disposable distro '$DistroName'. Review retained evidence/state before retrying or deleting the distro."
+}
+
+$EvidencePath = "/root/pantheon-local-tools-wsl-validation/$FromVersion-to-$ToVersion/evidence.txt"
+
+Write-Host
+Write-Host '=== READ BACK PUBLIC-SAFE EVIDENCE ==='
+& wsl.exe -d $DistroName -u root -- cat $EvidencePath
+if ($LASTEXITCODE -ne 0) {
+    throw 'Validation passed but evidence readback failed. Keep the disposable distro for inspection.'
+}
+
+Write-Host
+Write-Host '=== COMPLETE ==='
+Write-Host "Disposable distro retained for review: $DistroName"
+Write-Host 'No distro was unregistered.'

--- a/tests/test-wsl2-apt-upgrade-harness.sh
+++ b/tests/test-wsl2-apt-upgrade-harness.sh
@@ -28,12 +28,12 @@ if LC_ALL=C grep -q $'\r' "$HARNESS"; then
   fail 'PowerShell harness must use LF line endings so the embedded Bash payload is stable'
 fi
 
-assert_contains '[string]$FromVersion'
-assert_contains '[string]$ToVersion'
-assert_contains '[string]$DistroName'
-assert_contains '[switch]$ConfirmDisposableDistro'
-assert_contains '[string]$ExpectedOsId'
-assert_contains '[string]$ExpectedOsVersion'
+assert_contains "[string]\$FromVersion"
+assert_contains "[string]\$ToVersion"
+assert_contains "[string]\$DistroName"
+assert_contains "[switch]\$ConfirmDisposableDistro"
+assert_contains "[string]\$ExpectedOsId"
+assert_contains "[string]\$ExpectedOsVersion"
 
 assert_contains 'Refusing package validation without -ConfirmDisposableDistro'
 assert_contains 'Refusing to target the current default WSL distribution'
@@ -67,15 +67,15 @@ do
   assert_contains "$rc"
 done
 
-assert_contains 'apt-get install --yes "pantheon-local-tools=$FROM_VERSION"'
-assert_contains 'apt-get install --yes --only-upgrade "pantheon-local-tools=$TO_VERSION"'
-assert_contains 'apt-get install --yes --reinstall "pantheon-local-tools=$TO_VERSION"'
+assert_contains "apt-get install --yes \"pantheon-local-tools=\$FROM_VERSION\""
+assert_contains "apt-get install --yes --only-upgrade \"pantheon-local-tools=\$TO_VERSION\""
+assert_contains "apt-get install --yes --reinstall \"pantheon-local-tools=\$TO_VERSION\""
 assert_contains 'apt-get remove --yes pantheon-local-tools'
 assert_contains 'assert_config_unchanged'
 assert_contains 'assert_shell_unchanged'
 assert_contains "[System.Text.Encoding]::UTF8.GetBytes(\$LinuxScript)"
 assert_contains "[Convert]::ToBase64String(\$Bytes)"
-assert_contains "base64 -d | bash"
+assert_contains 'base64 -d | bash'
 assert_contains 'Target identity: explicitly named non-default disposable WSL2 distro verified'
 
 printf 'PASS: reusable WSL2 APT upgrade harness contract\n'

--- a/tests/test-wsl2-apt-upgrade-harness.sh
+++ b/tests/test-wsl2-apt-upgrade-harness.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+HARNESS="$ROOT_DIR/packaging/release/validate-wsl2-apt-upgrade.ps1"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local expected=$1
+  grep -Fq -- "$expected" "$HARNESS" ||
+    fail "harness is missing required contract text: $expected"
+}
+
+assert_not_contains() {
+  local unexpected=$1
+  if grep -Fq -- "$unexpected" "$HARNESS"; then
+    fail "harness contains forbidden hard-coded/unsafe text: $unexpected"
+  fi
+}
+
+[ -f "$HARNESS" ] || fail 'PowerShell harness is missing'
+
+if LC_ALL=C grep -q $'\r' "$HARNESS"; then
+  fail 'PowerShell harness must use LF line endings so the embedded Bash payload is stable'
+fi
+
+assert_contains '[string]$FromVersion'
+assert_contains '[string]$ToVersion'
+assert_contains '[string]$DistroName'
+assert_contains '[switch]$ConfirmDisposableDistro'
+assert_contains '[string]$ExpectedOsId'
+assert_contains '[string]$ExpectedOsVersion'
+
+assert_contains 'Refusing package validation without -ConfirmDisposableDistro'
+assert_contains 'Refusing to target the current default WSL distribution'
+assert_contains "'--',"
+assert_contains 'PLT_EXPECTED_DISTRO='
+assert_contains 'WSL_DISTRO_NAME'
+assert_contains 'microsoft-standard-WSL2'
+assert_contains 'validation state already exists'
+assert_contains 'Evidence/state remains inside'
+assert_contains 'No distro was unregistered.'
+
+assert_contains 'install-apt.sh'
+assert_contains 'APT_PRIMARY_FINGERPRINT'
+assert_contains 'APT_REPOSITORY_URL'
+assert_not_contains 'B75C45FA9E87AF56D7677F5785AF0D1C6E64C3F2'
+assert_not_contains '0.1.1'
+assert_not_contains '0.1.2'
+assert_not_contains 'wsl.exe --unregister'
+
+for rc in \
+  .bashrc \
+  .bash_profile \
+  .bash_login \
+  .profile \
+  .zshenv \
+  .zprofile \
+  .zshrc \
+  .zlogin \
+  .zlogout
+do
+  assert_contains "$rc"
+done
+
+assert_contains 'apt-get install --yes "pantheon-local-tools=$FROM_VERSION"'
+assert_contains 'apt-get install --yes --only-upgrade "pantheon-local-tools=$TO_VERSION"'
+assert_contains 'apt-get install --yes --reinstall "pantheon-local-tools=$TO_VERSION"'
+assert_contains 'apt-get remove --yes pantheon-local-tools'
+assert_contains 'assert_config_unchanged'
+assert_contains 'assert_shell_unchanged'
+assert_contains "[System.Text.Encoding]::UTF8.GetBytes(\$LinuxScript)"
+assert_contains "[Convert]::ToBase64String(\$Bytes)"
+assert_contains "base64 -d | bash"
+assert_contains 'Target identity: explicitly named non-default disposable WSL2 distro verified'
+
+printf 'PASS: reusable WSL2 APT upgrade harness contract\n'


### PR DESCRIPTION
## Summary

Implements #85 by turning the successful #84 one-off WSL2 release proof into reusable checked-in maintainer tooling.

- adds `packaging/release/validate-wsl2-apt-upgrade.ps1` with parameterized previous/current versions and explicit disposable distro targeting;
- refuses the current default WSL distro and requires `-ConfirmDisposableDistro` before package validation;
- verifies exact runtime distro identity, WSL2, optional OS expectations, the project-owned APT URL/fingerprint from `install-apt.sh`, published versions, and live candidate;
- seeds and byte-compares the nine guarded Bash/Zsh startup files before/after prerequisite install, previous-version install, APT upgrade, current-version reinstall, and package removal;
- verifies representative user-owned PLT config survives byte-for-byte;
- transfers the embedded Linux payload as UTF-8/Base64 to avoid CRLF/nested-quoting corruption;
- retains validation state/evidence on failure and never unregisters a distro automatically;
- emits sanitized evidence that omits the machine name, explicit distro name, usernames, and local paths;
- documents disposable distro creation, harness use, evidence review, manual cleanup, and process-local `-ExecutionPolicy Bypass` when Windows policy rejects an unsigned script invoked over a WSL UNC path;
- adds Bash contract coverage plus a Windows PowerShell parser CI job.

## Safety boundary

This PR does not run real APT validation on a maintainer's normal environment. Real package operations remain confined to an explicitly named disposable WSL2 target at maintainer invocation time. The harness also refuses whichever distro is currently marked as the WSL default.

## Validation

Automated validation passed on the implementation head before the final documentation-only clarification:

- Ubuntu shell syntax, ShellCheck, and full test suite;
- macOS shell syntax, ShellCheck, and full test suite;
- focused static harness safety/parameterization assertions;
- PowerShell syntax parsing on `windows-latest` without launching WSL or performing package operations.

Real checked-in harness proof also passed against a retained disposable Ubuntu 26.04 WSL2 distro using published `0.1.1 -> 0.1.2`:

- exact non-default disposable distro identity and WSL2 runtime verified;
- canonical archive fingerprint verified from project-owned metadata;
- signed public repository exposed both versions with 0.1.2 as live candidate;
- install, APT upgrade, reinstall, and removal all passed;
- CLI version transition was correct;
- representative user-owned config remained byte-for-byte unchanged;
- all nine guarded Bash/Zsh startup files remained byte-for-byte unchanged;
- public-safe evidence readback passed;
- disposable distro was retained and never unregistered automatically.

The first invocation was blocked by Windows execution policy before the script executed; the docs now cover a child-process-only `pwsh -ExecutionPolicy Bypass` invocation without changing persistent user or machine policy.

Closes #85.